### PR TITLE
Fix test matrix

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -36,7 +36,6 @@ jobs:
             "pull-request": [
               { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
@@ -45,7 +44,6 @@ jobs:
               { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "495" },

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -36,7 +36,6 @@ jobs:
             "pull-request": [
               { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
@@ -45,7 +44,6 @@ jobs:
               { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "495" },


### PR DESCRIPTION
This PR removes the CUDA `11.2.2` `arm` combinations from our tests matrices. `arm` images are only provided for CUDA versions greater than (but not equal to) `11.2.x`.