### PR TITLE
Drop `11.0` support

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -34,14 +34,11 @@ jobs:
         run: |
           export MATRICES='{
             "pull-request": [
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
@@ -55,7 +52,6 @@ jobs:
               { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "ext_nightly": [
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "t4", "DRIVER": "495" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "t4", "DRIVER": "495" }
             ]
           }'

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -34,11 +34,13 @@ jobs:
         run: |
           export MATRICES='{
             "pull-request": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
+              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [
+              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -34,14 +34,11 @@ jobs:
         run: |
           export MATRICES='{
             "pull-request": [
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
@@ -55,7 +52,6 @@ jobs:
               { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "ext_nightly": [
-              { "CUDA_VER": "11.0.3", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "t4", "DRIVER": "495" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "t4", "DRIVER": "495" }
             ]
           }'

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -34,11 +34,13 @@ jobs:
         run: |
           export MATRICES='{
             "pull-request": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
+              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [
+              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },


### PR DESCRIPTION
RAPIDS has recently dropped support for CUDA 11.0, so this PR updates our test matrices accordingly.

Similar to:

- https://github.com/rapidsai/mambaforge-cuda/commit/f7e6c714f779dc7a3e78bcfeaf5d05b570537bdd
- https://github.com/rapidsai/ci-imgs/commit/81ba0d0803cb53dff69bf2a289c6d7f0270a22a4