### PR TITLE
Update PR Test Matrix

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -41,6 +41,7 @@ jobs:
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
+              { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -41,6 +41,7 @@ jobs:
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
+              { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [


### PR DESCRIPTION
This PR updates our `pull-request` test matrix to ensure that we're testing the latest supported CUDA version on the earliest supported driver.

This combination of CUDA and driver version was causing a problem that is resolved in the `rmm` PR below.

- https://github.com/rapidsai/rmm/pull/1121