### PR TITLE
Update `test-summary/action`

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: C++ tests
         run: ci/test_cpp.sh
       - name: Generate test report
-        uses: test-summary/action@v1
+        uses: test-summary/action@v2
         with:
           paths: "${{ inputs.tests_result_dir }}/*.xml"
         if: always()

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Python tests
         run: ci/test_python.sh
       - name: Generate test report
-        uses: test-summary/action@v1
+        uses: test-summary/action@v2
         with:
           paths: "${{ inputs.tests_result_dir }}/*.xml"
         if: always()


### PR DESCRIPTION
This PR updates the `test-summary/action` action to the latest version to eliminate a deprecation message that keeps popping up in our logs (i.e. https://github.com/rapidsai/actions/actions/runs/3262603748).

`v2` was released a few days ago: https://github.com/test-summary/action/releases/tag/v2.0