### PR TITLE
Make test scripts configurable

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -18,6 +18,9 @@ on:
       tests_result_dir:
         type: string
         default: "test-results"
+      test_script:
+        type: string
+        default: "ci/test_cpp.sh"
 
 jobs:
   compute-matrix:
@@ -101,7 +104,7 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: C++ tests
-        run: ci/test_cpp.sh
+        run: ${{ inputs.test_script }}
       - name: Generate test report
         uses: test-summary/action@v2
         with:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -18,6 +18,9 @@ on:
       tests_result_dir:
         type: string
         default: "test-results"
+      test_script:
+        type: string
+        default: "ci/test_python.sh"
 
 jobs:
   compute-matrix:
@@ -101,7 +104,7 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python tests
-        run: ci/test_python.sh
+        run: ${{ inputs.test_script }}
       - name: Generate test report
         uses: test-summary/action@v2
         with:


### PR DESCRIPTION
This PR makes the CPP and Python test scripts configurable. This enables us to use these shared workflows in a parent workflow multiple times with different shell scripts. The benefit of this is that we can parallelize Python package tests (e.g. testing `cudf`, `dask-cudf`, `custreamz`, etc. at the same time).