### PR TITLE
Add custom-job.yaml

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      build_type:
+        required: true
+        type: string
+      branch:
+        type: string
+      date:
+        type: string
+      repo:
+        type: string
+      sha:
+        type: string
+      node_type:
+        type: string
+        default: "cpu8"
+      arch:
+        type: string
+        default: "amd64"
+      container_image:
+        type: string
+        default: "rapidsai/ci:latest"
+      run_script:
+        required: true
+        type: string
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on:
+      - self-hosted
+      - linux
+      - ${{ inputs.node_type }}
+      - ${{ inputs.arch }}
+    container:
+      image: ${{ inputs.container_image }}
+      env:
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
+        PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+      - name: Standardize repository information
+        run: |
+          echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
+          echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
+          echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
+          echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+      - name: Run script
+        run: ${{ inputs.run_script }}


### PR DESCRIPTION
This PR adds a workflow called `custom-job.yaml` that can be used for an arbitrary job (build, test, ...) that is not a full matrix build like typical C++ or Python builds/tests. This draft PR is being tested out in https://github.com/rapidsai/cudf/pull/12002 for Java tests, which are only run on one arch/version combination and thus can't use the existing C++/Python testing workflows.