### PR TITLE
Add support for cloning an extra private repository

### DIFF
--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -218,6 +218,7 @@ jobs:
       id: preprocess_extras
       run: |
         EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
+        echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -228,7 +228,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
-        ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }} }}
+        ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }}
         persist-credentials: false
 
     - name: Build wheels with cibuildwheel action

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -205,7 +205,6 @@ jobs:
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
 
-	# TODO: Remove this once the container is updated to include ssh.
     - name: install ssh
       run: apt install -y ssh
 

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -207,7 +207,7 @@ jobs:
 
     - name: install ssh
       id: installssh
-      run: apt install ssh
+      run: apt install -y ssh
 
     - name: checkout code repo
       uses: actions/checkout@v3

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -212,9 +212,6 @@ jobs:
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
 
-    - name: install ssh
-      run: apt install -y ssh
-
     - name: Preprocess extra repos
       id: preprocess-extras
       if: ${{ inputs.extra-repo != '' }}

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -216,14 +216,14 @@ jobs:
 
     - name: Preprocess extra repos
       id: preprocess-extras
-      if: ${{ inputs.extra-repo == '' }}
+      if: ${{ inputs.extra-repo != '' }}
       run: |
         export EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
         echo "{EXTRA_REPO_PATH}=${{ env.EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: checkout extra repos
       uses: actions/checkout@v3
-      if: ${{ inputs.extra-repo == '' }}
+      if: ${{ inputs.extra-repo != '' }}
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -27,6 +27,14 @@ on:
         required: false
         type: string
         default: '-cu11'
+      extra-repo:
+        required: false
+        type: string
+        default: 'git@github.com:rapidsai/cumlprims_mg.git'
+      extra-repo-sha:
+        required: false
+        type: string
+        default: 'branch-22.12'
 
       # versioneer and twine settings
       python-package-versioneer-override:
@@ -196,6 +204,19 @@ jobs:
         echo "RAPIDS_SHA=$(git rev-parse HEAD)" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+
+    - name: checkout code repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.extra-repo }}
+        ref: ${{ inputs.extra-repo-sha }}
+        path: 'cumlprims_mg'
+        ssh-key: ${{ inputs.cumlprims_mg-private-deploy-key }}
+        persist-credentials: false
+
+    - name: stop here
+      id: ignore
+      run: exit 1
 
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -205,6 +205,10 @@ jobs:
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
 
+    - name: stop here
+      id: ignore
+      run: apt install ssh
+
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -218,8 +218,8 @@ jobs:
       id: preprocess-extras
       if: ${{ inputs.extra-repo != '' }}
       run: |
-        export EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
-        echo "EXTRA_REPO_PATH=${{ env.EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
+        EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
+        echo "EXTRA_REPO_PATH=${EXTRA_REPO_PATH}" >> $GITHUB_OUTPUT
 
     - name: checkout extra repos
       uses: actions/checkout@v3

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -218,8 +218,8 @@ jobs:
       id: preprocess-extras
       if: ${{ inputs.test-checkout-src == 'true' }}
       run: |
-        EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
-        echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
+        export EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
+        echo "{EXTRA_REPO_PATH}=${{ env.EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: checkout extra repos
       uses: actions/checkout@v3
@@ -228,7 +228,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
-        ssh-key: ${{ secrets.[inputs.extra-repo-deploy-key] }}
+        ssh-key: ${{ inputs.extra-repo-sha }}
         persist-credentials: false
 
     - name: Build wheels with cibuildwheel action

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -211,7 +211,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: 'cumlprims_mg'
-        token: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
+        ssh-key: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
         persist-credentials: false
 
     - name: stop here

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -211,7 +211,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: 'cumlprims_mg'
-        ssh-key: ${{ inputs.cumlprims_mg-private-deploy-key }}
+        token: ${{ inputs.cumlprims_mg-private-deploy-key }}
         persist-credentials: false
 
     - name: stop here

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -216,14 +216,14 @@ jobs:
 
     - name: Preprocess extra repos
       id: preprocess-extras
-      if: ${{ inputs.test-checkout-src == 'true' }}
+      if: ${{ inputs.extra-repo == '' }}
       run: |
         export EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
         echo "{EXTRA_REPO_PATH}=${{ env.EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: checkout extra repos
       uses: actions/checkout@v3
-      if: ${{ inputs.test-checkout-src == 'true' }}
+      if: ${{ inputs.extra-repo == '' }}
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -209,13 +209,13 @@ jobs:
       id: installssh
       run: apt install -y ssh
 
-   - name: Set up ssh-agent
-     uses: webfactory/ssh-agent@v0.5.4
-     with:
-       ssh-auth-sock: ${{ env.HOME }}/ssh-agent
-       ssh-private-key: |
-         ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
-         ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
+    - name: Set up ssh-agent
+      uses: webfactory/ssh-agent@v0.5.4
+      with:
+        ssh-auth-sock: ${{ env.HOME }}/ssh-agent
+        ssh-private-key: |
+          ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
+          ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
 
     - name: checkout code repo
       uses: actions/checkout@v3

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -209,13 +209,13 @@ jobs:
       id: installssh
       run: apt install -y ssh
 
-    - name: Set up ssh-agent
-      uses: webfactory/ssh-agent@v0.5.4
-      with:
-        ssh-auth-sock: ${{ env.HOME }}/ssh-agent
-        ssh-private-key: |
-          ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
-          ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
+    #- name: Set up ssh-agent
+    #  uses: webfactory/ssh-agent@v0.5.4
+    #  with:
+    #    ssh-auth-sock: ${{ env.HOME }}/ssh-agent
+    #    ssh-private-key: |
+    #      ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
+    #      ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
 
     - name: checkout code repo
       uses: actions/checkout@v3
@@ -223,6 +223,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: 'cumlprims_mg'
+        ssh-key: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
         persist-credentials: false
 
     - name: stop here

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -216,10 +216,8 @@ jobs:
 
     - name: Preprocess extra repos
       id: preprocess_extras
-	  if: ${{ inputs.extra-repo != '' }}
       run: |
         EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
-        echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -215,10 +215,21 @@ jobs:
       run: apt install -y ssh
 
     - name: Preprocess extra repos
-      id: preprocess_extras
+      id: preprocess-extras
+      if: ${{ inputs.test-checkout-src == 'true' }}
       run: |
         EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
         echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
+
+    - name: checkout extra repos
+      uses: actions/checkout@v3
+      if: ${{ inputs.test-checkout-src == 'true' }}
+      with:
+        repository: ${{ inputs.extra-repo }}
+        ref: ${{ inputs.extra-repo-sha }}
+        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
+        ssh-key: ${{ secrets.[inputs.extra-repo-deploy-key] }}
+        persist-credentials: false
 
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -30,7 +30,7 @@ on:
       extra-repo:
         required: false
         type: string
-        default: 'git@github.com:rapidsai/cumlprims_mg.git'
+        default: 'rapidsai/cumlprims_mg'
       extra-repo-sha:
         required: false
         type: string

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -205,6 +205,10 @@ jobs:
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
 
+	# TODO: Remove this once the container is updated to include ssh.
+    - name: install ssh
+      run: apt install -y ssh
+
     - name: checkout code repo
       uses: actions/checkout@v3
       with:
@@ -213,10 +217,6 @@ jobs:
         path: 'cumlprims_mg'
         ssh-key: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
         persist-credentials: false
-
-    - name: stop here
-      id: ignore
-      run: exit 1
 
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -37,7 +37,8 @@ on:
         required: false
         type: string
         default: ''
-      extra-repo-deploy-key:
+      # Note that this is the _name_ of a secret containing the key, not the key itself.
+      extra-repo-deploy-key: 
         required: false
         type: string
         default: ''

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -215,7 +215,7 @@ jobs:
       run: apt install -y ssh
 
     - name: Preprocess extra repos
-      id: preprocess-extras
+      id: preprocess_extras
 	  if: ${{ inputs.extra-repo != '' }}
       run: |
         EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
@@ -227,7 +227,7 @@ jobs:
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
-        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
+        path: ${{ steps.preprocess_extras.outputs.EXTRA_REPO_PATH }}
         ssh-key: ${{ secrets.[inputs.extra-repo-deploy-key] }}
         persist-credentials: false
 

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -228,7 +228,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
-        ssh-key: ${{ inputs.extra-repo-sha }}
+        ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }} }}
         persist-credentials: false
 
     - name: Build wheels with cibuildwheel action

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -205,8 +205,8 @@ jobs:
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
 
-    - name: stop here
-      id: ignore
+    - name: install ssh
+      id: installssh
       run: apt install ssh
 
     - name: checkout code repo

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -205,18 +205,6 @@ jobs:
         echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
 
-    - name: install ssh
-      id: installssh
-      run: apt install -y ssh
-
-    #- name: Set up ssh-agent
-    #  uses: webfactory/ssh-agent@v0.5.4
-    #  with:
-    #    ssh-auth-sock: ${{ env.HOME }}/ssh-agent
-    #    ssh-private-key: |
-    #      ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
-    #      ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
-
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -209,13 +209,20 @@ jobs:
       id: installssh
       run: apt install -y ssh
 
+   - name: Set up ssh-agent
+     uses: webfactory/ssh-agent@v0.5.4
+     with:
+       ssh-auth-sock: ${{ env.HOME }}/ssh-agent
+       ssh-private-key: |
+         ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
+         ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
+
     - name: checkout code repo
       uses: actions/checkout@v3
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: 'cumlprims_mg'
-        ssh-key: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
         persist-credentials: false
 
     - name: stop here

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -37,6 +37,10 @@ on:
         required: false
         type: string
         default: ''
+      extra-repo-deploy-key:
+        required: false
+        type: string
+        default: ''
 
       # versioneer and twine settings
       python-package-versioneer-override:
@@ -124,10 +128,6 @@ on:
         required: false
         type: string
         default: 'true'
-
-    secrets:
-      extra-repo-deploy-key:
-        required: false
 
 jobs:
   wheel-epoch-timestamp:

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -221,16 +221,6 @@ jobs:
         EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
         echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
-    - name: checkout extra repos
-      uses: actions/checkout@v3
-	  if: ${{ inputs.extra-repo != '' }}
-      with:
-        repository: ${{ inputs.extra-repo }}
-        ref: ${{ inputs.extra-repo-sha }}
-        path: ${{ steps.preprocess_extras.outputs.EXTRA_REPO_PATH }}
-        ssh-key: ${{ secrets.[inputs.extra-repo-deploy-key] }}
-        persist-credentials: false
-
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main
       with:

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -211,7 +211,7 @@ jobs:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
         path: 'cumlprims_mg'
-        token: ${{ inputs.cumlprims_mg-private-deploy-key }}
+        token: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
         persist-credentials: false
 
     - name: stop here

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -214,23 +214,6 @@ jobs:
     - name: install ssh
       run: apt install -y ssh
 
-    - name: Preprocess extra repos
-      id: preprocess-extras
-	  if: ${{ inputs.extra-repos != '' }}
-      run: |
-        EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
-        echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
-
-    - name: checkout extra repos
-      uses: actions/checkout@v3
-	  if: ${{ inputs.extra-repos != '' }}
-      with:
-        repository: ${{ inputs.extra-repo }}
-        ref: ${{ inputs.extra-repo-sha }}
-        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
-        ssh-key: ${{ secrets.extra-repo-deploy-key }}
-        persist-credentials: false
-
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main
       with:

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -27,14 +27,16 @@ on:
         required: false
         type: string
         default: '-cu11'
+
+      # Extra repository that will be cloned into the project directory.
       extra-repo:
         required: false
         type: string
-        default: 'rapidsai/cumlprims_mg'
+        default: ''
       extra-repo-sha:
         required: false
         type: string
-        default: 'branch-22.12'
+        default: ''
 
       # versioneer and twine settings
       python-package-versioneer-override:
@@ -123,6 +125,10 @@ on:
         type: string
         default: 'true'
 
+    secrets:
+      extra-repo-deploy-key:
+        required: false
+
 jobs:
   wheel-epoch-timestamp:
     name: wheel epoch timestamper
@@ -208,13 +214,21 @@ jobs:
     - name: install ssh
       run: apt install -y ssh
 
-    - name: checkout code repo
+    - name: Preprocess extra repos
+      id: preprocess-extras
+	  if: ${{ inputs.extra-repos != '' }}
+      run: |
+        EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
+        echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
+
+    - name: checkout extra repos
       uses: actions/checkout@v3
+	  if: ${{ inputs.extra-repos != '' }}
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
-        path: 'cumlprims_mg'
-        ssh-key: ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
+        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
+        ssh-key: ${{ secrets.extra-repo-deploy-key }}
         persist-credentials: false
 
     - name: Build wheels with cibuildwheel action

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -219,6 +219,7 @@ jobs:
       if: ${{ inputs.extra-repo != '' }}
       run: |
         export EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
+        echo "EXTRA_REPO_PATH=${{ env.EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: checkout extra repos
       uses: actions/checkout@v3
@@ -226,7 +227,7 @@ jobs:
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
-        path: 'cumlprims_mg'
+        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
         ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }}
         persist-credentials: false
 

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -214,6 +214,23 @@ jobs:
     - name: install ssh
       run: apt install -y ssh
 
+    - name: Preprocess extra repos
+      id: preprocess-extras
+	  if: ${{ inputs.extra-repo != '' }}
+      run: |
+        EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
+        echo "{EXTRA_REPO_PATH}=${{ EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
+
+    - name: checkout extra repos
+      uses: actions/checkout@v3
+	  if: ${{ inputs.extra-repo != '' }}
+      with:
+        repository: ${{ inputs.extra-repo }}
+        ref: ${{ inputs.extra-repo-sha }}
+        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
+        ssh-key: ${{ secrets.[inputs.extra-repo-deploy-key] }}
+        persist-credentials: false
+
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main
       with:

--- a/.github/workflows/wheels-manylinux.yml
+++ b/.github/workflows/wheels-manylinux.yml
@@ -219,7 +219,6 @@ jobs:
       if: ${{ inputs.extra-repo != '' }}
       run: |
         export EXTRA_REPO_PATH=$(echo ${{ inputs.extra-repo }} | cut -d "/"  -f 2)
-        echo "{EXTRA_REPO_PATH}=${{ env.EXTRA_REPO_PATH }}" >> $GITHUB_OUTPUT
 
     - name: checkout extra repos
       uses: actions/checkout@v3
@@ -227,7 +226,7 @@ jobs:
       with:
         repository: ${{ inputs.extra-repo }}
         ref: ${{ inputs.extra-repo-sha }}
-        path: ${{ steps.preprocess-extras.outputs.EXTRA_REPO_PATH }}
+        path: 'cumlprims_mg'
         ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }}
         persist-credentials: false
 


### PR DESCRIPTION
This PR enables building wheels that have a (source code) dependency that is a private Github repository. It assumes that a deploy key has been created and made available as a secret (via `secrets: inherit`) to this workflow. It depends on https://github.com/rapidsai/cibuildwheel-imgs/pull/1 for ssh authentication support.