### PR TITLE
Use `codecov` from CI images

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -15,9 +15,6 @@ on:
       extended_nightly_tests:
         type: boolean
         default: false
-      tests_result_dir:
-        type: string
-        default: "test-results"
       test_script:
         type: string
         default: "ci/test_cpp.sh"
@@ -83,6 +80,8 @@ jobs:
       - linux
       - gpu-${{ matrix.includes.GPU }}-${{ matrix.includes.DRIVER }}-1
       - ${{ matrix.includes.ARCH }}
+    env:
+      RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
     container:
       image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:
@@ -108,5 +107,5 @@ jobs:
       - name: Generate test report
         uses: test-summary/action@v2
         with:
-          paths: "${{ inputs.tests_result_dir }}/*.xml"
+          paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -118,18 +118,7 @@ jobs:
       - name: Run codecov
         if: inputs.run_codecov && inputs.build_type == 'pull-request'
         run: |
-          #!/bin/bash
-          set -ex
-          env | sort
-          curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-          curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov
-          curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod +x codecov
-
-          ./codecov \
+          codecov \
             -s \
             "${RAPIDS_COVERAGE_DIR}" \
             -v

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -15,9 +15,6 @@ on:
       extended_nightly_tests:
         type: boolean
         default: false
-      tests_result_dir:
-        type: string
-        default: "test-results"
       test_script:
         type: string
         default: "ci/test_python.sh"
@@ -88,6 +85,7 @@ jobs:
       - ${{ matrix.includes.ARCH }}
     env:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
+      RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
     container:
       image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:
@@ -113,7 +111,7 @@ jobs:
       - name: Generate test report
         uses: test-summary/action@v2
         with:
-          paths: "${{ inputs.tests_result_dir }}/*.xml"
+          paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
       - name: Run codecov
         if: |

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -116,7 +116,10 @@ jobs:
           paths: "${{ inputs.tests_result_dir }}/*.xml"
         if: always()
       - name: Run codecov
-        if: inputs.run_codecov && inputs.build_type == 'pull-request'
+        if: |
+          inputs.run_codecov &&
+          inputs.build_type == 'pull-request' &&
+          contains(fromJson('["X64", "X86"]'), runner.arch)
         run: |
           codecov \
             -s \

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -114,10 +114,7 @@ jobs:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
       - name: Run codecov
-        if: |
-          inputs.run_codecov &&
-          inputs.build_type == 'pull-request' &&
-          contains(fromJson('["X64", "X86"]'), runner.arch)
+        if: inputs.run_codecov && contains(fromJson('["X64", "X86"]'), runner.arch)
         run: |
           codecov \
             -s \

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -119,7 +119,8 @@ jobs:
         if: inputs.run_codecov && inputs.build_type == 'pull-request'
         run: |
           #!/bin/bash
-          set -euox pipefail
+          set -ex
+          env | sort
           curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
           curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov
           curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
@@ -130,5 +131,5 @@ jobs:
 
           ./codecov \
             -s \
-            ${{ env.RAPIDS_COVERAGE_DIR }} \
+            "${RAPIDS_COVERAGE_DIR}" \
             -v

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -114,7 +114,7 @@ jobs:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
       - name: Run codecov
-        if: inputs.run_codecov && contains(fromJson('["X64", "X86"]'), runner.arch)
+        if: inputs.run_codecov && runner.arch == 'X64'
         run: |
           codecov \
             -s \

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -115,8 +115,20 @@ jobs:
         with:
           paths: "${{ inputs.tests_result_dir }}/*.xml"
         if: always()
-      - uses: codecov/codecov-action@v3
+      - name: Run codecov
         if: inputs.run_codecov && inputs.build_type == 'pull-request'
-        with:
-          directory: ${{ env.RAPIDS_COVERAGE_DIR }}
-          verbose: true
+        run: |
+          #!/bin/bash
+          set -euox pipefail
+          curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+          curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov
+          curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
+          chmod +x codecov
+
+          ./codecov \
+            -s \
+            ${{ env.RAPIDS_COVERAGE_DIR }} \
+            -v


### PR DESCRIPTION
This PR includes the following changes:

- Updates the `codecov` implementation to use the binary included in our CI images
  - This is to address the intermittent timeouts that we were experiencing with `codecov/codecov-action@v3`
- Ensures that `codecov` only runs on `x86`/`x86_64` machines
  - codecov doesn't support `arm`, see [this issue](https://github.com/codecov/uploader/issues/523)
- Removes the `build_type == 'pull-request'` restriction from the `codecov` step
  - This is to ensure we have `codecov` results for `base` branches (see [here](https://docs.codecov.com/docs/error-reference#missing-base-report) for why that's important)
- Creates a new `RAPIDS_TESTS_DIR` environment variable whose value is a directory path where unit test results can be saved to
  - This is similar to the `RAPIDS_COVERAGE_DIR` environment variable from #20
  - As a result of this change, I've also removed the `tests_result_dir` input