### PR TITLE
Remove `merge-gatekeeper`

### DIFF
--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -5,11 +5,4 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: upsidr/merge-gatekeeper@v1
-        with:
-          self: "pr-builder / run"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          interval: 60
-          timeout: 86400 # 24h
-          ref: ${{ github.ref }}
-          ignored: "triage,Branch Checker,Label Checker"
+      - run: exit 0

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -5,4 +5,5 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      # This reusable workflow should depend on all other jobs in the calling workflow.
       - run: exit 0


### PR DESCRIPTION
This PR removes `merge-gatekeeper`. We have to remove it due to some rate-limiting errors we were getting on high-volume repositories like `cudf`.

According to the GH docs below, the `GITHUB_TOKEN` provided by GitHub Actions is limited to 1000 requests per repository per hour. This limit is not enough for repos like `cudf`.

https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#requests-from-github-actions