### PR TITLE
Reduce number of driver-450 tests

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -39,9 +39,8 @@ jobs:
           export MATRICES='{
             "pull-request": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
-              { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -42,9 +42,8 @@ jobs:
           export MATRICES='{
             "pull-request": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "495" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.9", "GPU": "v100", "DRIVER": "495" },
-              { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.9", "GPU": "a100", "DRIVER": "495" }
             ],
             "nightly": [


### PR DESCRIPTION
Due to our current limited GPU resources, this PR reduces the number of driver 450 tests that run in CI on pull requests.