### PR TITLE
Update default `node_type` for `custom-job.yaml`

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -17,7 +17,7 @@ on:
         default: "amd64"
       node_type:
         type: string
-        default: "cpu8"
+        default: "gpu-v100-495-1"
       container_image:
         type: string
         default: "rapidsai/ci:latest"


### PR DESCRIPTION
I think it makes sense to set the default `node_type` variable for `custom-job.yaml` to be a GPU machine for the following reasons:

- GPU labels are subject to change often (e.g. when we update our supported CUDA/driver versions)
- CPU labels are relatively static

Since GPU labels can change often, it makes sense to have this default value specified once in this shared repository as opposed to being specified across several repositories.

Once this is merged, we should open up a follow-up PR to `cudf` to remove the `node_type` value in the two areas below:

- https://github.com/rapidsai/cudf/blob/f60877c87836ed4f484bf50d8e5b0a3f104ffeff/.github/workflows/test.yaml#L56
- https://github.com/rapidsai/cudf/blob/f60877c87836ed4f484bf50d8e5b0a3f104ffeff/.github/workflows/pr.yaml#L67

