### PR TITLE
Add shared job to check `pr-builder` job dependencies

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,8 +24,7 @@ on:
         required: false
 
 jobs:
-  check-size:
-    if: ${{ inputs.enable_check_size }}
+  other-checks:
     runs-on: ubuntu-latest
     container:
       image: rapidsai/ci:latest
@@ -38,9 +37,13 @@ jobs:
         id: get-pr-info
         uses: rapidsai/shared-action-workflows/get-pr-info@main
       - name: Run rapids-size-checker
+        if: ${{ inputs.enable_check_size }}
         run: rapids-size-checker
         env:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+      - name: Check workflow file dependencies
+        if: ${{ inputs.enable_check_pr_job_dependencies }}
+        run: rapids-check-pr-job-dependencies
   check-style:
     if: ${{ inputs.enable_check_style }}
     runs-on: ubuntu-latest
@@ -72,13 +75,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Run rapids-dependency-file-checker
         run: rapids-dependency-file-checker ${{ inputs.dependency_generator_config_file_path }}
-  check-pr-job-dependencies:
-    if: ${{ inputs.enable_check_pr_job_dependencies }}
-    runs-on: ubuntu-latest
-    container:
-      image: rapidsai/ci:latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Check workflow file dependencies
-        run: rapids-check-pr-job-dependencies

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,6 +18,10 @@ on:
         default: true
         type: boolean
         required: false
+      enable_check_pr_job_dependencies:
+        default: true
+        type: boolean
+        required: false
 
 jobs:
   check-size:
@@ -68,3 +72,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Run rapids-dependency-file-checker
         run: rapids-dependency-file-checker ${{ inputs.dependency_generator_config_file_path }}
+  check-pr-job-dependencies:
+    if: ${{ inputs.enable_check_pr_job_dependencies }}
+    runs-on: ubuntu-latest
+    container:
+      image: rapidsai/ci:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check workflow file dependencies
+        run: rapids-check-pr-job-dependencies


### PR DESCRIPTION
This PR adds a new check to run `rapids-check-pr-job-dependencies`.

Details on what that script does and why it's needed can be found below.

- https://github.com/rapidsai/gha-tools/pull/30

Additionally, the PR consolidates some checks that aren't likely to fail very often (e.g. `size-checker` and this new `pr-job-dependencies` check) into a new job called `other-checks`.