### PR TITLE
Add feature to skip uploading `conda` packages

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -12,6 +12,8 @@ on:
         type: string
       repo:
         type: string
+      skip_upload_pkgs:
+        type: string
 
 jobs:
   upload:
@@ -43,3 +45,5 @@ jobs:
           echo "RAPIDS_CONDA_TOKEN=${RAPIDS_CONDA_TOKEN}" >> "${GITHUB_ENV}"
       - name: Upload packages
         run: rapids-upload-to-anaconda
+        env:
+          SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}


### PR DESCRIPTION
This PR adds a new input, `skip_upload_pkgs`, to the `conda-upload-packages.yaml` workflow.

The value of this input is passed as an environment variable to the `rapids-upload-to-anaconda` script.

With the PR below merged, this will allow repositories to specify a space-delimited list of `conda` package names that should not be uploaded to Anaconda.org.

- https://github.com/rapidsai/gha-tools/pull/32

It can be used like this:

```yaml
upload-conda:
    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main
    with:
      skip_upload_pkgs: pkg1 pkg2 pkg3

# or with YAML multi-line features
upload-conda:
    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main
    with:
      skip_upload_pkgs: >-
        pkg1
        pkg2
        pkg3
```