### PR TITLE
Checkout code before checking git sha

### DIFF
--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -44,6 +44,14 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}
         TWINE_REPOSITORY_URL: "https://pypi.k8s.rapids.ai/simple/"
     steps:
+    - name: checkout code repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repo }}
+        ref: ${{ inputs.sha }}
+        fetch-depth: 0 # unshallow fetch for setuptools-scm
+        persist-credentials: false
+
     - name: Standardize repository information
       uses: rapidsai/shared-action-workflows/rapids-github-info@main
       with:

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -26,10 +26,6 @@ on:
         required: false
         type: string
         default: '-e _NOOP'
-      test-checkout-src: # allow one to skip checking out source code to run packaged tests
-        required: false
-        type: string
-        default: 'true'
       test-unittest: # tests are allowed to be blank because the wheel is installed and pip checked
         required: false
         type: string
@@ -117,7 +113,6 @@ jobs:
 
     - name: checkout code repo
       uses: actions/checkout@v3
-      if: ${{ inputs.test-checkout-src == 'true' }}
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -44,6 +44,14 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}
         TWINE_REPOSITORY_URL: "https://pypi.k8s.rapids.ai/simple/"
     steps:
+    - name: checkout code repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repo }}
+        ref: ${{ inputs.sha }}
+        fetch-depth: 0 # unshallow fetch for setuptools-scm
+        persist-credentials: false
+
     - name: Standardize repository information
       uses: rapidsai/shared-action-workflows/rapids-github-info@main
       with:

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -20,10 +20,6 @@ on:
         required: true
         type: string
 
-      test-checkout-src:
-        required: false
-        type: string
-        default: 'true'
       test-unittest:
         required: false
         type: string
@@ -61,7 +57,6 @@ jobs:
 
     - name: checkout code repo
       uses: actions/checkout@v3
-      if: ${{ inputs.test-checkout-src == 'true' }}
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}


### PR DESCRIPTION
The "Standardize github information" job runs `git rev-parse HEAD` to get the sha from the code. The problem is in the publish step, there is no code checked out.

This PR adds a source code checkout to the publish step.