### PR TITLE
Support workflow-local wheel dependencies

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -39,6 +39,12 @@ on:
         type: string
         default: ''
 
+      # run command before cibw
+      before-wheel:
+        type: string
+        required: false
+        default: 'true'
+
       # cibw settings
       cibw-environment:
         type: string
@@ -153,6 +159,9 @@ jobs:
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}
+
+    - name: Run before-wheel command
+      run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
       uses: rapidsai/shared-action-workflows/cibuildwheel@main

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -50,6 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "rapidsai/cibuildwheel:cuda-runtime-${{ matrix.ctk }}-ubuntu18.04"
+      env:
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        RAPIDS_PY_VERSION: "3.8"
+        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
+
     steps:
     - name: checkout code repo
       uses: actions/checkout@v3
@@ -85,8 +91,3 @@ jobs:
 
     - name: Upload wheels to downloads.rapids.ai
       run: rapids-upload-wheels-to-s3 dist
-      env:
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_PY_VERSION: "3.8"
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -86,7 +86,7 @@ jobs:
       run: |
         versioneer_override="$(rapids-pip-wheel-version ${{ needs.wheel-epoch-timestamp.outputs.rapids_epoch_timestamp }})"
         export RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE="${versioneer_override}"
-        python -m pip wheel -w ./dist ${{ inputs.package-dir }} --no-deps
+        python -m pip wheel -w ./dist ${{ inputs.package-dir }} --no-deps -vvv
       shell: bash
 
     - name: Upload wheels to downloads.rapids.ai

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -23,6 +23,12 @@ on:
         required: true
         type: string
 
+      # run command before pure wheel build
+      before-wheel:
+        type: string
+        required: false
+        default: 'true'
+
 jobs:
   wheel-epoch-timestamp:
     name: wheel epoch timestamper
@@ -66,6 +72,9 @@ jobs:
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}
+
+    - name: Run before-wheel command
+      run: "${{ inputs.before-wheel }}"
 
     - name: Build pure python wheel with pip wheel
       run: |


### PR DESCRIPTION
Create new wheel build parameters: `before-wheel`

This allows us to use `rapids-download-wheels-from-s3` to have inter-dependent wheels within a single workflow download the dependency wheels _built in this current workflow run_ instead of pulling the nightly published copy.

Tested for pure wheels in cuDF: https://github.com/rapidsai/cudf/pull/12427
Tested for manylinux wheels in RAFT: https://github.com/rapidsai/raft/pull/1116 