### PR TITLE
Add `upload_to_label` input to `conda-upload-packages.yaml`

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -14,6 +14,10 @@ on:
         type: string
       skip_upload_pkgs:
         type: string
+      upload_to_label:
+        description: The label that should be applied to packages uploaded to Anaconda.org
+        type: string
+        default: main
 
 jobs:
   upload:
@@ -47,3 +51,4 @@ jobs:
         run: rapids-upload-to-anaconda
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
+          RAPIDS_CONDA_UPLOAD_LABEL: $${{ inputs.upload_to_label }}


### PR DESCRIPTION
This PR adds a new input, `upload_to_label`, to the `conda-upload-packages.yaml` reusable workflow.

This input allows callers to specify what label should be applied to packages that are uploaded to Anaconda.org

This is needed for `cumlprims_mg`. Those packages by default get uploaded to a `testing` label and then later get manually moved to the `main` label.

The workflow input variable is passed to the `rapids-upload-to-anaconda` script as an environment variable called `RAPIDS_CONDA_UPLOAD_LABEL`. See link below for more details.

- https://github.com/rapidsai/gha-tools/blob/ef8d60c4702c768879bcd7a84977a89733ca2ef8/tools/rapids-upload-to-anaconda#L61