### PR TITLE
Replace versioneer overrides with manual modification of package source

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -164,7 +164,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@main
+      uses: rapidsai/shared-action-workflows/cibuildwheel@replace_versioneer
       with:
         # hardcoded
         output-dir: dist

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -90,12 +90,6 @@ runs:
 
         # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
-        echo "Currently in ${pwd}"
-        echo "One"
-        ls 
-        echo "Two"
-        ls ci
-        ls ci/release
         bash ci/release/modify_wheel_build_version.sh ${versioneer_override}
         echo "The git diff after modifying the versions is:"
         git diff

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -83,7 +83,6 @@ runs:
         skbuild_config_opts="${{ inputs.skbuild-configure-options}}"
         skbuild_config_opts="${skbuild_config_opts} -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=/usr/bin/sccache"
 
-
         # convert 3.x to cp3x-*
         python_ver=${{ inputs.python-version }}
         python_ver="${python_ver//./}"
@@ -93,6 +92,8 @@ runs:
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
         pushd ${{ inputs.package-dir }}
         bash modify_wheel_build_version.sh ${versioneer_override}
+        echo "The git diff after modifying the versions is:"
+        git diff
         popd
 
         # assemble CIBW_ENVIRONMENT from skbuild configure and build options

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -83,16 +83,20 @@ runs:
         skbuild_config_opts="${{ inputs.skbuild-configure-options}}"
         skbuild_config_opts="${skbuild_config_opts} -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=/usr/bin/sccache"
 
-        # use gha-tools rapids-pip-wheel-version to generate wheel version
-        versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
 
         # convert 3.x to cp3x-*
         python_ver=${{ inputs.python-version }}
         python_ver="${python_ver//./}"
         echo "CIBW_BUILD=cp${python_ver}-*" >> "${GITHUB_ENV}"
 
+        # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
+        versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
+        pushd ${{ inputs.package-dir }}
+        bash modify_wheel_build_version.sh ${versioneer_override}
+        popd
+
         # assemble CIBW_ENVIRONMENT from skbuild configure and build options
-        echo "CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}' SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-west-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple" >> "${GITHUB_ENV}"
+        echo "CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-west-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Invoke cibuildwheel

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -90,6 +90,12 @@ runs:
 
         # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
+        echo "Currently in ${pwd}"
+        echo "One"
+        ls 
+        echo "Two"
+        ls ci
+        ls ci/release
         bash ci/release/modify_wheel_build_version.sh ${versioneer_override}
         echo "The git diff after modifying the versions is:"
         git diff

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -90,11 +90,9 @@ runs:
 
         # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
-        pushd ${{ inputs.package-dir }}
         bash ci/release/modify_wheel_build_version.sh ${versioneer_override}
         echo "The git diff after modifying the versions is:"
         git diff
-        popd
 
         # assemble CIBW_ENVIRONMENT from skbuild configure and build options
         echo "CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-west-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple" >> "${GITHUB_ENV}"

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -91,7 +91,7 @@ runs:
         # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
         pushd ${{ inputs.package-dir }}
-        bash modify_wheel_build_version.sh ${versioneer_override}
+        bash ci/release/modify_wheel_build_version.sh ${versioneer_override}
         echo "The git diff after modifying the versions is:"
         git diff
         popd


### PR DESCRIPTION
This PR replaces setting the `RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE` environment variable for consumption within Python packages with instead directly modifying metadata in the package. It relies on each package to provide a script `ci/release/modify_wheel_build_version.sh` that can be executed at wheel build time to perform all the necessary version replacements.