### PR TITLE
Build pip wheels with CTK 11.8 and py3.10

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -97,9 +97,9 @@ jobs:
     needs: wheel-epoch-timestamp
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.10']
         arch: [amd64, arm64]
-        ctk: ['11.5.1']
+        ctk: ['11.8.0']
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.10']
         linux-arch: ["x86_64", "aarch64"]
-        ctk: ['11.5.1']
+        ctk: ['11.8.0']
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -65,14 +65,14 @@ jobs:
           export MATRICES=$(cat <<EOF
           {
             "pull-request": [
-              { "arch": "amd64", "python": "3.8", "ctk": "11.5.1", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "495"  },
-              { "arch": "arm64", "python": "3.8", "ctk": "11.5.1", "image": "ubuntu20.04", "test-type": "smoke", "test-command": "${{ inputs.test-smoketest }}", "gpu": "a100", "driver": "495"  }
+              { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520"  },
+              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "smoke", "test-command": "${{ inputs.test-smoketest }}", "gpu": "a100", "driver": "520"  }
             ],
             "nightly": [
-              { "arch": "amd64", "python": "3.8", "ctk": "11.5.1", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "495" },
-              { "arch": "amd64", "python": "3.9", "ctk": "11.5.1", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "495" },
-              { "arch": "arm64", "python": "3.8", "ctk": "11.5.1", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "495" },
-              { "arch": "arm64", "python": "3.9", "ctk": "11.5.1", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "495" }
+              { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520" },
+              { "arch": "amd64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520" },
+              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "520" },
+              { "arch": "arm64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "520" }
             ]
           }
           EOF)

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -46,7 +46,7 @@ jobs:
     needs: wheel-epoch-timestamp
     strategy:
       matrix:
-        ctk: ["11.5.1"]
+        ctk: ["11.8.0"]
     runs-on: ubuntu-latest
     container:
       image: "rapidsai/cibuildwheel:cuda-runtime-${{ matrix.ctk }}-ubuntu18.04"

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         python: ['3.8']
         linux-arch: ["x86_64"]
-        ctk: ['11.5.1']
+        ctk: ['11.8.0']
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, linux, amd64, gpu-v100-495-1]
     strategy:
       matrix:
-        ctk: ["11.5.1"]
+        ctk: ["11.8.0"]
     container:
       image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-ubuntu18.04"
       env:


### PR DESCRIPTION
Switches the CTK 11.5.1 -> 11.8.0, and py 3.9 -> 3.10 for pip wheel builds (similar to Conda)