### PR TITLE
Cuda 118 sccache disable

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -80,6 +80,12 @@ on:
         type: string
         default: ''
 
+      # disable sccache for cugraph
+      sccache-enabled:
+        required: false
+        type: string
+        default: "yes"
+
 jobs:
   wheel-epoch-timestamp:
     name: wheel epoch timestamper
@@ -164,7 +170,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@main
+      uses: rapidsai/shared-action-workflows/cibuildwheel@cuda-118
       with:
         # hardcoded
         output-dir: dist
@@ -187,6 +193,9 @@ jobs:
         cibw-before-build: ${{ inputs.cibw-before-build }}
         skbuild-configure-options: ${{ inputs.skbuild-configure-options }}
         skbuild-build-options: ${{ inputs.skbuild-build-options }}
+
+        # allow sccache to be disabled
+        sccache-enabled: ${{ inputs.sccache-enabled }}
 
         # secrets
         sccache-aws-access-key-id: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -170,7 +170,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@cuda-118
+      uses: rapidsai/shared-action-workflows/cibuildwheel@cuda-118-sccache-disable
       with:
         # hardcoded
         output-dir: dist

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -55,6 +55,10 @@ inputs:
   sccache-aws-secret-access-key:
     required: true
     type: string
+  sccache-enabled:
+    required: false
+    type: string
+    default: yes
 
 runs:
   using: composite
@@ -81,7 +85,9 @@ runs:
 
         # enable sccache in skbuild config options
         skbuild_config_opts="${{ inputs.skbuild-configure-options}}"
-        skbuild_config_opts="${skbuild_config_opts} -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=/usr/bin/sccache"
+        if [[ "${{ inputs.sccache-enabled }}" == "yes" ]]; then
+          skbuild_config_opts="${skbuild_config_opts} -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=/usr/bin/sccache"
+        fi
 
         # use gha-tools rapids-pip-wheel-version to generate wheel version
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"


### PR DESCRIPTION
Merge some changes on `cibuildwheel@main` into `@cuda-118`, and add some parameters to allow sccache to be disabled to get past some cugraph build errors.