### PR TITLE
Add & run `update-version.sh`, Remove Python `3.9` builds

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@main
+        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.02
       - name: Run rapids-size-checker
         if: ${{ inputs.enable_check_size }}
         run: rapids-size-checker
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@main
+        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.02
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -26,8 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -39,21 +39,21 @@ jobs:
           export MATRICES='{
             "pull-request": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
             ],
             "nightly": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "520" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
             ],

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -58,7 +58,7 @@ jobs:
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
             ],
             "ext_nightly": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "495" }
+              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "520" }
             ]
           }'
 

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.10" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.10" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.8" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.8" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -27,8 +27,6 @@ jobs:
         include:
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.9" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.9" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.10" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.10" }
     runs-on:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -61,7 +61,7 @@ jobs:
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
             ],
             "ext_nightly": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "495" }
+              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "520" }
             ]
           }'
 

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -42,21 +42,21 @@ jobs:
           export MATRICES='{
             "pull-request": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
             ],
             "nightly": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu18.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "520" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
             ],

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -136,7 +136,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@main
+      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.02
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -161,7 +161,7 @@ jobs:
         persist-credentials: false
 
     - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@main
+      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.02
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}
@@ -170,7 +170,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@main
+      uses: rapidsai/shared-action-workflows/cibuildwheel@branch-23.02
       with:
         # hardcoded
         output-dir: dist

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -53,7 +53,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@main
+      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.02
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -61,7 +61,7 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@main
+      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.02
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -120,7 +120,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@main
+      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.02
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -128,7 +128,7 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@main
+      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.02
       with:
         ctk: ${{ matrix.includes.ctk }}
         package-name: ${{ inputs.package-name }}

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -66,7 +66,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@main
+      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.02
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -74,7 +74,7 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@main
+      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.02
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -53,7 +53,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@main
+      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.02
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -61,7 +61,7 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@main
+      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.02
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -64,7 +64,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@main
+      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.02
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -72,7 +72,7 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@main
+      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.02
       with:
         ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+###########################################
+# shared-action-workflows Version Updater #
+###########################################
+
+## Usage
+# bash update-version.sh <new_version>
+
+# Format is YY.MM.PP - no leading 'v' or trailing 'a'
+NEXT_FULL_TAG=$1
+
+#Get <major>.<minor> for next version
+NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
+
+echo "Updating repository for $NEXT_FULL_TAG"
+
+# Inplace sed replace; workaround for Linux and Mac
+function sed_runner() {
+    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+}
+
+for FILE in .github/workflows/*.{yaml,yml}; do
+  sed_runner "/rapidsai\/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+done


### PR DESCRIPTION
This PR includes the following changes:

- Adds an `update-version.sh` script
- Runs the `update-version.sh` script in order to update all branch references to `branch-23.02`
- Removes Python `3.9` builds from `branch-23.02` since RAPIDS no longer builds that version
- Updates conda C++ builds to use latest Ubuntu / Python images
- Updates conda Python builds to use latest Ubuntu images
- Removes ubuntu 18.04 from tests


The implication of the second bullet is that every time we create a new branch, all of the composite action references will also be updated.

I think that's fine, but it's something we'll need to be conscious of.

I think we should try to keep the reusable workflow branches and composite action branches in-sync.

For example, if we need to test a composite action change, we should do so on a separate branch. And then update the reusable workflow to call the newly changed composite action on that branch.

Thoughts on this, @sevagh?


Keeping these workflows and composite actions in-sync will become easier if/when the following discussions are ever addressed by GitHub. I'm currently subscribed to them.

- https://github.com/community/community/discussions/18601
- https://github.com/community/community/discussions/18602

