### PR TITLE
Add RAPIDS_ARTIFACTS_DIR env var to conda-cpp-build.yaml

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -33,6 +33,8 @@ jobs:
       - linux
       - ${{ inputs.node_type }}
       - ${{ matrix.ARCH }}
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
       image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -81,6 +81,7 @@ jobs:
       - ${{ matrix.includes.ARCH }}
     env:
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
       image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -34,6 +34,8 @@ jobs:
       - linux
       - ${{ inputs.node_type }}
       - ${{ matrix.ARCH }}
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
       image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -85,6 +85,7 @@ jobs:
     env:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
       image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:


### PR DESCRIPTION
Adds `RAPIDS_ARTIFACTS_DIR` environment variable to `conda-cpp-build.yaml`.
This sets up a directory for uploading artifacts in RAPIDS builds to be available for download once the workflow completes.
The artifacts directory is useful for build metrics and other logs to help developers diagnose issues.

