### PR TITLE
Use AWS OIDC to get AWS creds

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -28,6 +28,8 @@ jobs:
         include:
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -37,10 +39,12 @@ jobs:
       image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -74,6 +74,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -85,11 +87,13 @@ jobs:
       image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -95,6 +95,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -29,6 +29,8 @@ jobs:
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.8" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -38,10 +40,12 @@ jobs:
       image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -77,6 +77,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -89,11 +91,13 @@ jobs:
       image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -99,6 +99,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -21,14 +21,18 @@ on:
 
 jobs:
   upload:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     container:
       image: rapidsai/ci:latest
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -29,6 +29,8 @@ jobs:
   build:
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -38,11 +40,13 @@ jobs:
       image: ${{ inputs.container_image }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -106,6 +106,8 @@ jobs:
         python: ['3.8', '3.10']
         arch: [amd64, arm64]
         ctk: ['11.8.0']
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -123,10 +125,12 @@ jobs:
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         RAPIDS_PY_VERSION: ${{ matrix.python }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
 
     steps:
+    - uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_REGION }}
     - name: checkout code repo
       uses: actions/checkout@v3
       with:
@@ -195,8 +199,8 @@ jobs:
         skbuild-build-options: ${{ inputs.skbuild-build-options }}
 
         # secrets
-        sccache-aws-access-key-id: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        sccache-aws-secret-access-key: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
+        sccache-aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+        sccache-aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
         internal-pypi-user: cibuildwheel
         internal-pypi-pass: ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}
 

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -214,6 +214,7 @@ jobs:
         # secrets
         sccache-aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
         sccache-aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+        sccache-aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
         internal-pypi-user: cibuildwheel
         internal-pypi-pass: ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}
 

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -141,6 +141,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: ${{ vars.AWS_REGION }}
+        role-duration-seconds: 43200 # 12h
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -30,6 +30,8 @@ jobs:
         python: ['3.8', '3.10']
         linux-arch: ["x86_64", "aarch64"]
         ctk: ['11.8.0']
+    permissions:
+      id-token: write
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine
@@ -38,12 +40,14 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         RAPIDS_ARCH: ${{ matrix.linux-arch }}
         RAPIDS_PY_VERSION: ${{ matrix.python }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         TWINE_USERNAME: cibuildwheel
         TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}
         TWINE_REPOSITORY_URL: "https://pypi.k8s.rapids.ai/simple/"
     steps:
+    - uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_REGION }}
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: ${{ vars.AWS_REGION }}
+        role-duration-seconds: 43200 # 12h
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -85,6 +85,8 @@ jobs:
     needs: wheel-test-compute-matrix
     strategy:
       matrix: ${{ fromJSON(needs.wheel-test-compute-matrix.outputs.MATRIX) }}
+    permissions:
+      id-token: write
     runs-on:
       - self-hosted
       - linux
@@ -97,14 +99,16 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
         RAPIDS_PY_VERSION: ${{ matrix.includes.python }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         RAPIDS_BEFORE_TEST_COMMANDS_AMD64: ${{ inputs.test-before-amd64 }}
         RAPIDS_BEFORE_TEST_COMMANDS_ARM64: ${{ inputs.test-before-arm64 }}
         PIP_EXTRA_INDEX_URL: "https://pypi.k8s.rapids.ai/simple"
         CIBW_TEST_EXTRAS: "test"
         CIBW_TEST_COMMAND: ${{ matrix.includes.test-command }}
     steps:
+    - uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_REGION }}
     - name: Run nvidia-smi to make sure GPU is working
       run: nvidia-smi
 

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -109,6 +109,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: ${{ vars.AWS_REGION }}
+        role-duration-seconds: 43200 # 12h
     - name: Run nvidia-smi to make sure GPU is working
       run: nvidia-smi
 

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -71,6 +71,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: ${{ vars.AWS_REGION }}
+        role-duration-seconds: 43200 # 12h
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -47,16 +47,20 @@ jobs:
     strategy:
       matrix:
         ctk: ["11.8.0"]
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     container:
       image: "rapidsai/cibuildwheel:cuda-runtime-${{ matrix.ctk }}-ubuntu20.04"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         RAPIDS_PY_VERSION: "3.8"
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
 
     steps:
+    - uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_REGION }}
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: ${{ vars.AWS_REGION }}
+        role-duration-seconds: 43200 # 12h
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -30,6 +30,8 @@ jobs:
         python: ['3.8']
         linux-arch: ["x86_64"]
         ctk: ['11.8.0']
+    permissions:
+      id-token: write
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine
@@ -38,12 +40,14 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         RAPIDS_ARCH: ${{ matrix.linux-arch }}
         RAPIDS_PY_VERSION: ${{ matrix.python }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         TWINE_USERNAME: cibuildwheel
         TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}
         TWINE_REPOSITORY_URL: "https://pypi.k8s.rapids.ai/simple/"
     steps:
+    - uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_REGION }}
     - name: checkout code repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -53,6 +53,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: ${{ vars.AWS_REGION }}
+        role-duration-seconds: 43200 # 12h
     - name: Run nvidia-smi to make sure GPU is working
       run: nvidia-smi
 

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -36,19 +36,23 @@ jobs:
     strategy:
       matrix:
         ctk: ["11.8.0"]
+    permissions:
+      id-token: write
     container:
       image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-ubuntu18.04"
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
         RAPIDS_PY_VERSION: "3.8"
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         RAPIDS_BEFORE_TEST_COMMANDS_AMD64: ${{ inputs.test-before }}
         CIBW_TEST_EXTRAS: "test"
         CIBW_TEST_COMMAND: ${{ inputs.test-unittest }}
         PIP_EXTRA_INDEX_URL: "https://pypi.k8s.rapids.ai/simple"
     steps:
+    - uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_REGION }}
     - name: Run nvidia-smi to make sure GPU is working
       run: nvidia-smi
 

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -55,6 +55,9 @@ inputs:
   sccache-aws-secret-access-key:
     required: true
     type: string
+  sccache-aws-session-token:
+    required: true
+    type: string
   # TODO: The below flag is to support the older packaging structure. We
   # can remove it once all packages building wheels have migrated away from
   # the old structure.
@@ -99,7 +102,7 @@ runs:
 
         # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
-        env_var="CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-east-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache-east SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse"
+        env_var="CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-east-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache-east SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} AWS_SESSION_TOKEN=${{ inputs.sccache-aws-session-token }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse"
 
         if [ "${{ inputs.uses-setup-env-vars }}" = true ]; then
           env_var="${env_var} RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}' RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}'"


### PR DESCRIPTION
This PR is using the AWS OIDC to get AWS credentials ([doc](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)). The `AWS_ROLE_ARN` and `AWS_REGION` are orgs variables defined here: https://github.com/organizations/rapidsai/settings/variables/actions