### PR TITLE
Switch pip wheels to new us-east sccache bucket

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -170,7 +170,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@branch-23.04
+      uses: rapidsai/shared-action-workflows/cibuildwheel@upkeep/pip-wheel-improvements
       with:
         # hardcoded
         output-dir: dist

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -170,7 +170,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@upkeep/pip-wheel-improvements
+      uses: rapidsai/shared-action-workflows/cibuildwheel@branch-23.04
       with:
         # hardcoded
         output-dir: dist

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -92,7 +92,7 @@ runs:
         echo "CIBW_BUILD=cp${python_ver}-*" >> "${GITHUB_ENV}"
 
         # assemble CIBW_ENVIRONMENT from skbuild configure and build options
-        echo "CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}' SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-west-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse" >> "${GITHUB_ENV}"
+        echo "CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}' SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-east-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache-east SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Invoke cibuildwheel


### PR DESCRIPTION
After upgrading sccache to 0.3.3 in the manylinux image, this change switches to the new us-east sccache bucket: https://github.com/rapidsai/manylinux/commit/b13c3c7fb8194b162e7f3fdf851af0e707cc1cf4

I'm currently testing this branch with a cuDF build: https://github.com/rapidsai/cudf/pull/12782 