### PR TITLE
Allow scripts to overwrite package names with a prerun script rather than using an env variable

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -86,16 +86,12 @@ on:
         type: string
         default: ''
 
-      # TODO: The below flags are to support the older packaging structure. We can
-      # remove them once all packages building wheels have migrated away from the
-      # old structure.
-      # Enable libraries that aren't using versioneer
-      uses-versioneer:
-        required: false
-        type: boolean
-        default: true
-      # Enable libraries that don't use RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
-      uses-dynamic-name:
+      # TODO: The below flag is to support the older packaging structure. We
+      # can remove it once all packages building wheels have migrated away from
+      # the old structure.
+      # Enable libraries that aren't using versioneer or
+      # RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
+      uses-setup-env-vars:
         required: false
         type: boolean
         default: true
@@ -209,8 +205,7 @@ jobs:
         skbuild-build-options: ${{ inputs.skbuild-build-options }}
 
         # versioneer
-        uses-versioneer: ${{ inputs.uses-versioneer }}
-        uses-dynamic-name: ${{ inputs.uses-dynamic-name }}
+        uses-setup-env_vars: ${{ inputs.uses-setup-env-vars }}
 
         # secrets
         sccache-aws-access-key-id: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -205,7 +205,7 @@ jobs:
         skbuild-build-options: ${{ inputs.skbuild-build-options }}
 
         # versioneer
-        uses-setup-env_vars: ${{ inputs.uses-setup-env-vars }}
+        uses-setup-env-vars: ${{ inputs.uses-setup-env-vars }}
 
         # secrets
         sccache-aws-access-key-id: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -180,7 +180,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@static_wheel_name
+      uses: rapidsai/shared-action-workflows/cibuildwheel@branch-23.04
       with:
         # hardcoded
         output-dir: dist

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -86,8 +86,16 @@ on:
         type: string
         default: ''
 
+      # TODO: The below flags are to support the older packaging structure. We can
+      # remove them once all packages building wheels have migrated away from the
+      # old structure.
       # Enable libraries that aren't using versioneer
       uses-versioneer:
+        required: false
+        type: boolean
+        default: true
+      # Enable libraries that don't use RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
+      uses-dynamic-name:
         required: false
         type: boolean
         default: true
@@ -202,6 +210,7 @@ jobs:
 
         # versioneer
         uses-versioneer: ${{ inputs.uses-versioneer }}
+        uses-dynamic-name: ${{ inputs.uses-dynamic-name }}
 
         # secrets
         sccache-aws-access-key-id: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -184,7 +184,7 @@ jobs:
       run: "${{ inputs.before-wheel }}"
 
     - name: Build wheels with cibuildwheel action
-      uses: rapidsai/shared-action-workflows/cibuildwheel@branch-23.04
+      uses: rapidsai/shared-action-workflows/cibuildwheel@static_wheel_name
       with:
         # hardcoded
         output-dir: dist

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -29,16 +29,12 @@ on:
         required: false
         default: 'true'
 
-      # TODO: The below flags are to support the older packaging structure. We can
-      # remove them once all packages building wheels have migrated away from the
-      # old structure.
-      # Enable libraries that aren't using versioneer
-      uses-versioneer:
-        required: false
-        type: boolean
-        default: true
-      # Enable libraries that don't use RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
-      uses-dynamic-name:
+      # TODO: The below flag is to support the older packaging structure. We
+      # can remove it once all packages building wheels have migrated away from
+      # the old structure.
+      # Enable libraries that aren't using versioneer or
+      # RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
+      uses-setup-env-vars:
         required: false
         type: boolean
         default: true
@@ -87,10 +83,6 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
-    # TODO: When all libraries are not using dynamic names and we remove the
-    # uses-dynamic-name option, we can move this step to after the build stage
-    # to make it clear exactly where the name gets used. At that point we can
-    # also remove the suffix setting in the composite action.
     - name: Set CTK-related vars from input CTK versions
       uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.04
       with:
@@ -104,11 +96,8 @@ jobs:
       run: |
         versioneer_override="$(rapids-pip-wheel-version ${{ needs.wheel-epoch-timestamp.outputs.rapids_epoch_timestamp }})"
 
-        if [ "${{ inputs.uses-versioneer }}" = true ]; then
+        if [ "${{ inputs.uses-setup-env-vars }}" = true ]; then
           export RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE="${versioneer_override}"
-        fi
-
-        if [ "${{ inputs.uses-versioneer }}" = false ] || [ "${{ inputs.uses-dynamic-name }}" = false ]; then
           bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_CUDA_SUFFIX}
           echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -109,7 +109,7 @@ jobs:
         fi
 
         if [ "${{ inputs.uses-versioneer }}" = false ] || [ "${{ inputs.uses-dynamic-name }}" = false ]; then
-          bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_NAME}
+          bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_CUDA_SUFFIX}
           echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff
         fi

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -29,8 +29,16 @@ on:
         required: false
         default: 'true'
 
+      # TODO: The below flags are to support the older packaging structure. We can
+      # remove them once all packages building wheels have migrated away from the
+      # old structure.
       # Enable libraries that aren't using versioneer
       uses-versioneer:
+        required: false
+        type: boolean
+        default: true
+      # Enable libraries that don't use RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
+      uses-dynamic-name:
         required: false
         type: boolean
         default: true
@@ -79,6 +87,10 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
+    # TODO: When all libraries are not using dynamic names and we remove the
+    # uses-dynamic-name option, we can move this step to after the build stage
+    # to make it clear exactly where the name gets used. At that point we can
+    # also remove the suffix setting in the composite action.
     - name: Set CTK-related vars from input CTK versions
       uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.04
       with:
@@ -94,9 +106,11 @@ jobs:
 
         if [ "${{ inputs.uses-versioneer }}" = true ]; then
           export RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE="${versioneer_override}"
-        else
-          bash ci/release/apply_wheel_modifications.sh ${versioneer_override}
-          echo "The git diff after modifying the versions is:"
+        fi
+
+        if [ "${{ inputs.uses-versioneer }}" = false ] || [ "${{ inputs.uses-dynamic-name }}" = false ]; then
+          bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_NAME}
+          echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff
         fi
 

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -98,6 +98,7 @@ jobs:
 
         if [ "${{ inputs.uses-setup-env-vars }}" = true ]; then
           export RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE="${versioneer_override}"
+        else
           bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_CUDA_SUFFIX}
           echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -112,7 +112,7 @@ runs:
         fi
 
         if [ "${{ inputs.uses-versioneer }}" = false ] || [ "${{ inputs.uses-dynamic-name }}" = false ]; then
-          bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_NAME}
+          bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_CUDA_SUFFIX}
           echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff
         fi

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -55,14 +55,12 @@ inputs:
   sccache-aws-secret-access-key:
     required: true
     type: string
-  # TODO: The below flags are to support the older packaging structure. We can
-  # remove them once all packages building wheels have migrated away from the
-  # old structure.
-  uses-versioneer:
-    required: false
-    type: boolean
-    default: true
-  uses-dynamic-name:
+  # TODO: The below flag is to support the older packaging structure. We
+  # can remove it once all packages building wheels have migrated away from
+  # the old structure.
+  # Enable libraries that aren't using versioneer or
+  # RAPIDS_PY_WHEEL_CUDA_SUFFIX in setup.py
+  uses-setup-env-vars:
     required: false
     type: boolean
     default: true
@@ -103,15 +101,9 @@ runs:
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
         env_var="CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-east-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache-east SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse"
 
-        if [ "${{ inputs.uses-versioneer }}" = true ]; then
-          env_var="${env_var} RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}'"
-        fi
-
-        if [ "${{ inputs.uses-dynamic-name }}" = true ]; then
-          env_var="${env_var} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' "
-        fi
-
-        if [ "${{ inputs.uses-versioneer }}" = false ] || [ "${{ inputs.uses-dynamic-name }}" = false ]; then
+        if [ "${{ inputs.uses-setup-env-vars }}" = true ]; then
+          env_var="${env_var} RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}' RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}'"
+        else
           bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_CUDA_SUFFIX}
           echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -55,7 +55,14 @@ inputs:
   sccache-aws-secret-access-key:
     required: true
     type: string
+  # TODO: The below flags are to support the older packaging structure. We can
+  # remove them once all packages building wheels have migrated away from the
+  # old structure.
   uses-versioneer:
+    required: false
+    type: boolean
+    default: true
+  uses-dynamic-name:
     required: false
     type: boolean
     default: true
@@ -94,13 +101,19 @@ runs:
 
         # Use gha-tools rapids-pip-wheel-version to generate wheel version then update the necessary files
         versioneer_override="$(rapids-pip-wheel-version ${{ inputs.epoch-timestamp }})"
-        env_var="CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-east-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache-east SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse"
+        env_var="CIBW_ENVIRONMENT=SKBUILD_CONFIGURE_OPTIONS='${skbuild_config_opts}' SKBUILD_BUILD_OPTIONS='${{ inputs.skbuild-build-options }}' ${{ inputs.cibw-environment }} SCCACHE_S3_KEY_PREFIX=gha-cibw SCCACHE_REGION=us-east-2 SCCACHE_IDLE_TIMEOUT=32768 SCCACHE_BUCKET=rapids-sccache-east SCCACHE_S3_USE_SSL=true AWS_ACCESS_KEY_ID=${{ inputs.sccache-aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ inputs.sccache-aws-secret-access-key }} PIP_INDEX_URL=https://pypi.k8s.rapids.ai/simple PIP_FIND_LINKS=/project/local-wheelhouse"
 
         if [ "${{ inputs.uses-versioneer }}" = true ]; then
           env_var="${env_var} RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE='${versioneer_override}'"
-        else
-          bash ci/release/apply_wheel_modifications.sh ${versioneer_override}
-          echo "The git diff after modifying the versions is:"
+        fi
+
+        if [ "${{ inputs.uses-dynamic-name }}" = true ]; then
+          env_var="${env_var} RAPIDS_PY_WHEEL_CUDA_SUFFIX='${{ inputs.cuda-suffix }}' "
+        fi
+
+        if [ "${{ inputs.uses-versioneer }}" = false ] || [ "${{ inputs.uses-dynamic-name }}" = false ]; then
+          bash ci/release/apply_wheel_modifications.sh ${versioneer_override} ${RAPIDS_PY_WHEEL_NAME}
+          echo "The package name and/or version was modified in the package source. The git diff is:"
           git diff
         fi
 

--- a/wheel-ctk-name-gen/action.yml
+++ b/wheel-ctk-name-gen/action.yml
@@ -5,8 +5,6 @@ inputs:
   package-name:
     type: string
 outputs:
-  # TODO: We should remove RAPIDS_PY_WHEEL_CUDA_SUFFIX once no repo leverages
-  # it in setup.py.
   rapids_py_cuda_suffix:
     value: ${{ steps.ctk-gen.outputs.RAPIDS_PY_WHEEL_CUDA_SUFFIX }}
   rapids_py_wheel_name:

--- a/wheel-ctk-name-gen/action.yml
+++ b/wheel-ctk-name-gen/action.yml
@@ -5,6 +5,8 @@ inputs:
   package-name:
     type: string
 outputs:
+  # TODO: We should remove RAPIDS_PY_WHEEL_CUDA_SUFFIX once no repo leverages
+  # it in setup.py.
   rapids_py_cuda_suffix:
     value: ${{ steps.ctk-gen.outputs.RAPIDS_PY_WHEEL_CUDA_SUFFIX }}
   rapids_py_wheel_name:


### PR DESCRIPTION
This PR builds on #38 to remove environment variable-based dynamic names from wheels, instead using the same script defined by #38 to modify any static files directly.