### PR TITLE
Sequential wheel uploads

### DIFF
--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -55,9 +55,5 @@ jobs:
 
     - name: Download wheels from downloads.rapids.ai and publish to internal PyPI
       run: |
-        for arch in x86_64 aarch64; do
-          for pyver in 3.8 3.10; do
-            RAPIDS_ARCH="${arch}" RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_cu11" RAPIDS_PY_VERSION="${pyver}" rapids-download-wheels-from-s3 ./dist
-          done
-        done
-        rapids-twine ./dist/
+        wget "https://raw.githubusercontent.com/sevagh/gha-tools/feat/rapids-twine-bulk-upload/tools/rapids-twine" -O ./rapids-twine-pr-45 && chmod +x ./rapids-twine-pr-45
+        ./rapids-twine-pr-45

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -25,19 +25,12 @@ jobs:
   wheel-publish:
     name: wheels publish
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ['3.8', '3.10']
-        linux-arch: ["x86_64", "aarch64"]
-        ctk: ['11.8.0']
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine
       image: "rapidsai/cibuildwheel:cuda-runtime-11.8.0-ubuntu20.04"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_ARCH: ${{ matrix.linux-arch }}
-        RAPIDS_PY_VERSION: ${{ matrix.python }}
         AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         TWINE_USERNAME: cibuildwheel
@@ -60,13 +53,11 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
-    - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.04
-      with:
-        ctk: ${{ matrix.ctk }}
-        package-name: ${{ inputs.package-name }}
-
-    - name: Download wheel from downloads.rapids.ai and publish to internal PyPI
+    - name: Download wheels from downloads.rapids.ai and publish to internal PyPI
       run: |
-        rapids-download-wheels-from-s3 ./dist
+        for arch in x86_64 aarch64; do
+          for pyver in 3.8 3.10; do
+            RAPIDS_ARCH="${arch}" RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_cu11" RAPIDS_PY_VERSION="${pyver}" rapids-download-wheels-from-s3 ./dist
+          done
+        done
         rapids-twine ./dist/

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -56,4 +56,4 @@ jobs:
     - name: Download wheels from downloads.rapids.ai and publish to internal PyPI
       run: |
         wget "https://raw.githubusercontent.com/sevagh/gha-tools/feat/rapids-twine-bulk-upload/tools/rapids-twine" -O ./rapids-twine-pr-45 && chmod +x ./rapids-twine-pr-45
-        ./rapids-twine-pr-45
+        ./rapids-twine-pr-45 "${{ inputs.package-name }}"

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -54,6 +54,4 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Download wheels from downloads.rapids.ai and publish to internal PyPI
-      run: |
-        wget "https://raw.githubusercontent.com/sevagh/gha-tools/feat/rapids-twine-bulk-upload/tools/rapids-twine" -O ./rapids-twine-pr-45 && chmod +x ./rapids-twine-pr-45
-        ./rapids-twine-pr-45 "${{ inputs.package-name }}"
+      run: rapids-twine "${{ inputs.package-name }}"

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -55,5 +55,5 @@ jobs:
 
     - name: Download wheel from downloads.rapids.ai and publish to internal PyPI
       run: |
-        RAPIDS_ARCH="x86_64" RAPIDS_PY_VER="3.8" RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_cu11" rapids-download-wheels-from-s3 ./dist
+        RAPIDS_ARCH="x86_64" RAPIDS_PY_VERSION="3.8" RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_cu11" rapids-download-wheels-from-s3 ./dist
         rapids-twine ./dist/

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -54,6 +54,4 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Download wheel from downloads.rapids.ai and publish to internal PyPI
-      run: |
-        wget "https://raw.githubusercontent.com/sevagh/gha-tools/feat/rapids-twine-bulk-upload/tools/rapids-twine" -O ./rapids-twine-pr-45 && chmod +x ./rapids-twine-pr-45
-        ./rapids-twine-pr-45 "${{ inputs.package-name }}"
+      run: rapids-twine "${{ inputs.package-name }}"

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -56,4 +56,4 @@ jobs:
     - name: Download wheel from downloads.rapids.ai and publish to internal PyPI
       run: |
         wget "https://raw.githubusercontent.com/sevagh/gha-tools/feat/rapids-twine-bulk-upload/tools/rapids-twine" -O ./rapids-twine-pr-45 && chmod +x ./rapids-twine-pr-45
-        ./rapids-twine-pr-45
+        ./rapids-twine-pr-45 "${{ inputs.package-name }}"

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -55,5 +55,5 @@ jobs:
 
     - name: Download wheel from downloads.rapids.ai and publish to internal PyPI
       run: |
-        RAPIDS_ARCH="x86_64" RAPIDS_PY_VERSION="3.8" RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_cu11" rapids-download-wheels-from-s3 ./dist
-        rapids-twine ./dist/
+        wget "https://raw.githubusercontent.com/sevagh/gha-tools/feat/rapids-twine-bulk-upload/tools/rapids-twine" -O ./rapids-twine-pr-45 && chmod +x ./rapids-twine-pr-45
+        ./rapids-twine-pr-45

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -25,19 +25,12 @@ jobs:
   wheel-publish:
     name: wheels publish
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ['3.8']
-        linux-arch: ["x86_64"]
-        ctk: ['11.8.0']
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine
       image: "rapidsai/cibuildwheel:cuda-runtime-11.8.0-ubuntu20.04"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_ARCH: ${{ matrix.linux-arch }}
-        RAPIDS_PY_VERSION: ${{ matrix.python }}
         AWS_ACCESS_KEY_ID: ${{ secrets.RAPIDSAI_GHA_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.RAPIDSAI_GHA_AWS_SECRET_ACCESS_KEY }}
         TWINE_USERNAME: cibuildwheel
@@ -60,13 +53,7 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
-    - name: Set CTK-related vars from input CTK versions
-      uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.04
-      with:
-        ctk: ${{ matrix.ctk }}
-        package-name: ${{ inputs.package-name }}
-
     - name: Download wheel from downloads.rapids.ai and publish to internal PyPI
       run: |
-        rapids-download-wheels-from-s3 ./dist
+        RAPIDS_ARCH="x86_64" RAPIDS_PY_VER="3.8" RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_cu11" rapids-download-wheels-from-s3 ./dist
         rapids-twine ./dist/


### PR DESCRIPTION
The parallel uploads may be overwhelming the internal index, leading to instability.

Tested for publishing cuDF and dask-cudf.