### PR TITLE
Update `a100` jobs to use driver `525`

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -41,7 +41,7 @@ jobs:
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
             ],
             "nightly": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
@@ -49,13 +49,13 @@ jobs:
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "525" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
             ],
             "ext_nightly": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "520" }

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -44,7 +44,7 @@ jobs:
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
             ],
             "nightly": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
@@ -52,13 +52,13 @@ jobs:
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "525" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" },
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" },
               { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "520" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "520" }
+              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
             ],
             "ext_nightly": [
               { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "520" }

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -65,14 +65,14 @@ jobs:
           export MATRICES=$(cat <<EOF
           {
             "pull-request": [
-              { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520"  },
-              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "smoke", "test-command": "${{ inputs.test-smoketest }}", "gpu": "a100", "driver": "520"  }
+              { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520" },
+              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "smoke", "test-command": "${{ inputs.test-smoketest }}", "gpu": "a100", "driver": "525" }
             ],
             "nightly": [
               { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520" },
               { "arch": "amd64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "520" },
-              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "520" },
-              { "arch": "arm64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "520" }
+              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" },
+              { "arch": "arm64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" }
             ]
           }
           EOF)


### PR DESCRIPTION
I am in the middle of updating our two `arm` nodes to driver `525`.

One of them has been updated, so we should update our current `a100` jobs to use this new driver so that I can update the other one.

We can leave the `CUDA_VER` for these `a100` jobs as `11.8` on `branch-23.04` and then update them to `12.0` on branch `cuda-120`.