### PR TITLE
Add step to upload artifacts

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -56,3 +56,6 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: C++ build
         run: ${{ inputs.build_script }}
+      - name: Upload artifacts
+        if: '!cancelled()'
+        run: rapids-upload-artifacts-dir

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -109,3 +109,6 @@ jobs:
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
+      - name: Upload artifacts
+        if: '!cancelled()'
+        run: rapids-upload-artifacts-dir

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -57,3 +57,6 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python build
         run: ${{ inputs.build_script }}
+      - name: Upload artifacts
+        if: '!cancelled()'
+        run: rapids-upload-artifacts-dir

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -120,3 +120,6 @@ jobs:
             -s \
             "${RAPIDS_COVERAGE_DIR}" \
             -v
+      - name: Upload artifacts
+        if: '!cancelled()'
+        run: rapids-upload-artifacts-dir


### PR DESCRIPTION
This PR adds a step to run `rapids-upload-artifacts-dir` (added [here](https://github.com/rapidsai/gha-tools/pull/43)) to any shared workflows that expose a `RAPIDS_ARTIFACTS_DIR` environment variable.