### PR TITLE
Fix shared workflow permissions

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -19,6 +19,21 @@ on:
         type: string
         default: "ci/build_cpp.sh"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
     timeout-minutes: 480
@@ -28,8 +43,6 @@ jobs:
         include:
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -19,6 +19,21 @@ on:
         type: string
         default: "ci/test_cpp.sh"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   compute-matrix:
     runs-on: ubuntu-latest
@@ -74,8 +89,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -19,6 +19,21 @@ on:
         type: string
         default: "ci/build_python.sh"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
     strategy:
@@ -29,8 +44,6 @@ jobs:
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.8" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -22,6 +22,21 @@ on:
         type: boolean
         default: true
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   compute-matrix:
     runs-on: ubuntu-latest
@@ -77,8 +92,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -19,10 +19,23 @@ on:
         type: string
         default: main
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   upload:
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
     container:
       image: rapidsai/ci:latest

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -25,12 +25,25 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
     strategy:
       fail-fast: false
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -96,6 +96,21 @@ on:
         type: boolean
         default: true
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   wheel-epoch-timestamp:
     name: wheel epoch timestamper
@@ -116,8 +131,6 @@ jobs:
         python: ['3.8', '3.10']
         arch: [amd64, arm64]
         ctk: ['11.8.0']
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -21,12 +21,25 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   wheel-publish:
     name: wheels publish
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -43,6 +43,21 @@ on:
         type: string
         default: 'true'
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   wheel-test-compute-matrix:
     runs-on: ubuntu-latest
@@ -85,8 +100,6 @@ jobs:
     needs: wheel-test-compute-matrix
     strategy:
       matrix: ${{ fromJSON(needs.wheel-test-compute-matrix.outputs.MATRIX) }}
-    permissions:
-      id-token: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -39,6 +39,21 @@ on:
         type: boolean
         default: true
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   wheel-epoch-timestamp:
     name: wheel epoch timestamper
@@ -57,8 +72,6 @@ jobs:
     strategy:
       matrix:
         ctk: ["11.8.0"]
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
     container:
       image: "rapidsai/cibuildwheel:cuda-runtime-${{ matrix.ctk }}-ubuntu20.04"

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -21,12 +21,25 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   wheel-publish:
     name: wheels publish
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     container:
       # ctk version of the cibw container is irrelevant in the publish step
       # it's simply a launcher for twine

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -29,6 +29,21 @@ on:
         type: string
         default: 'true'
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   wheel-test:
     name: wheel test pure
@@ -36,8 +51,6 @@ jobs:
     strategy:
       matrix:
         ctk: ["11.8.0"]
-    permissions:
-      id-token: write
     container:
       image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-ubuntu18.04"
       env:


### PR DESCRIPTION
After merging #43, there were some private repositories that were having issues checking out source code in GHAs.

Further investigation revealed that by omitting the other keys in the `permissions` block that was added, we were effectively setting them to `none` ([src](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview)).

To remedy this, this PR includes the following changes:

- Keeps the `id-token` permissions as `write`, but set the remaining permissions as described in the `restricted` column [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
  - We can always adjust this if needed, but I think this is fine
- Moves the `permissions` block to the top of each workflow so that it's applied to all jobs in each workflow file