### PR TITLE
Set `pull-requests` permissions to `read`

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -29,7 +29,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -29,7 +29,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -29,7 +29,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -32,7 +32,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -29,7 +29,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -35,7 +35,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -106,7 +106,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -31,7 +31,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -53,7 +53,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -49,7 +49,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -31,7 +31,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -39,7 +39,7 @@ permissions:
   issues: none
   packages: read
   pages: none
-  pull-requests: none
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none


### PR DESCRIPTION
This is a follow-up to #52.

In hindsight, we should set the `pull-requests` permission to `read` like @bdice suggested.

This will ensure that the [get-pr-info](https://github.com/rapidsai/shared-action-workflows/blob/93a3e440be17665911049908058c14c9e8a25304/get-pr-info/action.yml) composite action can use the token for retrieving pull-request metadata.