### PR TITLE
Change the default behavior for rewriting wheel names and versions.

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -94,7 +94,7 @@ on:
       uses-setup-env-vars:
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   actions: none

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -37,7 +37,7 @@ on:
       uses-setup-env-vars:
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   actions: none

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -66,7 +66,7 @@ inputs:
   uses-setup-env-vars:
     required: false
     type: boolean
-    default: true
+    default: false
 
 runs:
   using: composite


### PR DESCRIPTION
All RAPIDS libraries that build wheels have now been migrated away from versioneer and towards the new approach for versioning. In order to avoid any disruptive changes to other repos given the approach of burn down, this PR changes the default value of this parameter rather than removing it outright. That way, once this is merged each library can go through and remove the (now redundant) parameter from their workflows without any breakage, and we can then remove the associated code paths in the workflows in this repo.