### PR TITLE
Add python 3.9 back to manylinux wheel builds

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -128,7 +128,7 @@ jobs:
     needs: wheel-epoch-timestamp
     strategy:
       matrix:
-        python: ['3.8', '3.10']
+        python: ['3.8', '3.9', '3.10']
         arch: [amd64, arm64]
         ctk: ['11.8.0']
     runs-on:

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -85,8 +85,10 @@ jobs:
             ],
             "nightly": [
               { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
+              { "arch": "amd64", "python": "3.9", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
               { "arch": "amd64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
               { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" },
+              { "arch": "arm64", "python": "3.9", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" },
               { "arch": "arm64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" }
             ]
           }

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -88,7 +88,6 @@ jobs:
               { "arch": "amd64", "python": "3.9", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
               { "arch": "amd64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
               { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" },
-              { "arch": "arm64", "python": "3.9", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" },
               { "arch": "arm64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" }
             ]
           }


### PR DESCRIPTION
Google Colab needs Python 3.9 wheels, so we're building pip wheels for 3.9 too.