### PR TITLE
Add support for manipulating `conda` build/test matrices downstream

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -59,7 +59,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
           )" >> ${GITHUB_OUTPUT}
   build:
     needs: compute-matrix
@@ -71,11 +71,11 @@ jobs:
       - self-hosted
       - linux
       - ${{ inputs.node_type }}
-      - ${{ matrix.includes.ARCH }}
+      - ${{ matrix.ARCH }}
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
+      image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -18,6 +18,9 @@ on:
       build_script:
         type: string
         default: "ci/build_cpp.sh"
+      matrix_filter:
+        type: string
+        default: "."
 
 defaults:
   run:
@@ -39,23 +42,40 @@ permissions:
   statuses: none
 
 jobs:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
+    steps:
+      - name: Compute Build Matrix
+        id: compute-matrix
+        run: |
+          set -eo pipefail
+
+          export MATRIX='
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
+          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
+          '
+
+          echo "MATRIX=$(
+            yq -n -o json 'env(MATRIX)' | \
+            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+          )" >> ${GITHUB_OUTPUT}
   build:
+    needs: compute-matrix
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on:
       - self-hosted
       - linux
       - ${{ inputs.node_type }}
-      - ${{ matrix.ARCH }}
+      - ${{ matrix.includes.ARCH }}
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+      image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -18,6 +18,9 @@ on:
       test_script:
         type: string
         default: "ci/test_cpp.sh"
+      matrix_filter:
+        type: string
+        default: "."
 
 defaults:
   run:
@@ -55,39 +58,42 @@ jobs:
       - name: Compute C++ Test Matrix
         id: compute-matrix
         run: |
-          export MATRICES='{
-            "pull-request": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
-            ],
-            "nightly": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "525" },
-              { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
-            ],
-            "ext_nightly": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "525" }
-            ]
-          }'
+          set -eo pipefail
 
-          export TEST_MATRIX=$(jq -nc 'env.MATRICES | fromjson | .[env.BUILD_TYPE]')
+          export MATRICES='
+            pull-request:
+              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+            nightly:
+              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: "11.5.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.5.1", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+            ext_nightly:
+              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "t4", DRIVER: "525" }
+          '
+
+          TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
+          export TEST_MATRIX
 
           if [[ "${BUILD_TYPE}" == "nightly" && "${{inputs.extended_nightly_tests}}" == "true" ]]; then
-            TEST_MATRIX=$(jq -nc '(env.TEST_MATRIX|fromjson) + (env.MATRICES|fromjson|.ext_nightly)')
+            TEST_MATRIX=$(yq -n 'env(TEST_MATRIX) + (env(MATRICES)|.ext_nightly)')
           fi
 
-          echo "MATRIX=$(jq -nc 'env.TEST_MATRIX | fromjson | {includes: .}')" >> ${GITHUB_OUTPUT}
+          echo "MATRIX=$(
+            yq -n -o json 'env(TEST_MATRIX)' | \
+            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+          )" >> ${GITHUB_OUTPUT}
   tests:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -92,7 +92,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
           )" >> ${GITHUB_OUTPUT}
   tests:
     needs: compute-matrix
@@ -102,13 +102,13 @@ jobs:
     runs-on:
       - self-hosted
       - linux
-      - gpu-${{ matrix.includes.GPU }}-${{ matrix.includes.DRIVER }}-1
-      - ${{ matrix.includes.ARCH }}
+      - gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1
+      - ${{ matrix.ARCH }}
     env:
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
+      image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -61,7 +61,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
           )" >> ${GITHUB_OUTPUT}
   build:
     strategy:
@@ -71,11 +71,11 @@ jobs:
       - self-hosted
       - linux
       - ${{ inputs.node_type }}
-      - ${{ matrix.includes.ARCH }}
+      - ${{ matrix.ARCH }}
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
+      image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -18,6 +18,9 @@ on:
       build_script:
         type: string
         default: "ci/build_python.sh"
+      matrix_filter:
+        type: string
+        default: "."
 
 defaults:
   run:
@@ -39,24 +42,40 @@ permissions:
   statuses: none
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
+    steps:
+      - name: Compute Build Matrix
+        id: compute-matrix
+        run: |
+          set -eo pipefail
+
+          export MATRIX='
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.8" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.8" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
           - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
+          '
+
+          echo "MATRIX=$(
+            yq -n -o json 'env(MATRIX)' | \
+            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+          )" >> ${GITHUB_OUTPUT}
+  build:
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on:
       - self-hosted
       - linux
       - ${{ inputs.node_type }}
-      - ${{ matrix.ARCH }}
+      - ${{ matrix.includes.ARCH }}
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+      image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -95,7 +95,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
           )" >> ${GITHUB_OUTPUT}
   tests:
     needs: compute-matrix
@@ -105,14 +105,14 @@ jobs:
     runs-on:
       - self-hosted
       - linux
-      - gpu-${{ matrix.includes.GPU }}-${{ matrix.includes.DRIVER }}-1
-      - ${{ matrix.includes.ARCH }}
+      - gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1
+      - ${{ matrix.ARCH }}
     env:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci:cuda${{ matrix.includes.CUDA_VER }}-${{ matrix.includes.LINUX_VER }}-py${{ matrix.includes.PY_VER }}
+      image: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -21,6 +21,9 @@ on:
       run_codecov:
         type: boolean
         default: true
+      matrix_filter:
+        type: string
+        default: "."
 
 defaults:
   run:
@@ -58,39 +61,42 @@ jobs:
       - name: Compute Python Test Matrix
         id: compute-matrix
         run: |
-          export MATRICES='{
-            "pull-request": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
-            ],
-            "nightly": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "centos7", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.8", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.4.1", "LINUX_VER": "ubuntu20.04", "ARCH": "arm64", "PY_VER": "3.8", "GPU": "a100", "DRIVER": "525" },
-              { "CUDA_VER": "11.5.1", "LINUX_VER": "ubuntu20.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.5.1", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "450" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "ubuntu22.04", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "v100", "DRIVER": "525" },
-              { "CUDA_VER": "11.8.0", "LINUX_VER": "rockylinux8", "ARCH": "arm64", "PY_VER": "3.10", "GPU": "a100", "DRIVER": "525" }
-            ],
-            "ext_nightly": [
-              { "CUDA_VER": "11.2.2", "LINUX_VER": "ubuntu22.04", "ARCH": "amd64", "PY_VER": "3.10", "GPU": "t4", "DRIVER": "525" }
-            ]
-          }'
+          set -eo pipefail
 
-          export TEST_MATRIX=$(jq -nc 'env.MATRICES | fromjson | .[env.BUILD_TYPE]')
+          export MATRICES='
+            pull-request:
+              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+            nightly:
+              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: "11.5.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.5.1", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
+              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+            ext_nightly:
+              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "t4", DRIVER: "525" }
+          '
+
+          TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
+          export TEST_MATRIX
 
           if [[ "${BUILD_TYPE}" == "nightly" && "${{inputs.extended_nightly_tests}}" == "true" ]]; then
-            TEST_MATRIX=$(jq -nc '(env.TEST_MATRIX|fromjson) + (env.MATRICES|fromjson|.ext_nightly)')
+            TEST_MATRIX=$(yq -n 'env(TEST_MATRIX) + (env(MATRICES)|.ext_nightly)')
           fi
 
-          echo "MATRIX=$(jq -nc 'env.TEST_MATRIX | fromjson | {includes: .}')" >> ${GITHUB_OUTPUT}
+          echo "MATRIX=$(
+            yq -n -o json 'env(TEST_MATRIX)' | \
+            jq -c '${{ inputs.matrix_filter }} | {includes: .}' \
+          )" >> ${GITHUB_OUTPUT}
   tests:
     needs: compute-matrix
     strategy:


### PR DESCRIPTION
This PR introduces support for manipulating the default matrices in our shared build and test `conda` workflows from downstream repositories.


## Usage:

The filtering can be done via a new workflow input, `matrix_filter`.

`matrix_filter` is intended to contain a `jq` filter (see [docs](https://stedolan.github.io/jq/manual/)).

The `input` provided to `matrix_filter` is an array containing the default build matrix (e.g. [these values](https://github.com/rapidsai/shared-action-workflows/blob/d2eba320e08eedc5087596e47fca89d606058e8c/.github/workflows/conda-cpp-build.yaml#L56-L57)).

The default value of `matrix_filter` is `.` (the `jq` [identity filter](https://stedolan.github.io/jq/manual/#Identity:.)).

This example shows how `matrix_filter` can be used to remove `arm64` matrix combinations from the shared `conda-cpp-build.yaml` workflow.

```yaml
conda-cpp-build:
    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@branch-23.04
    with:
      matrix_filter: map(select(.ARCH != "arm64"))
```

## Additional Changes

This PR also:

- changes the syntax used to represent our default matrices from JSON to YAML since YAML is a little more forgiving. It uses `yq` to convert it back to JSON so that it can be consumed correctly by GHAs.
- switches our generated matrix to look like `{"include": [...]}` instead of `{"includes": [...]}`. This was a typo. Fixing the typo lets us reference the matrix values as `matrix.ARCH` instead of `matrix.includes.ARCH` (see [here](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations) for GHAs docs).