### PR TITLE
Add support for manipulating `wheel` build/test matrices downstream

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -29,6 +29,9 @@ on:
       package-dir:
         required: true
         type: string
+      matrix_filter:
+        type: string
+        default: "."
 
       # Extra repository that will be cloned into the project directory.
       extra-repo:
@@ -40,7 +43,7 @@ on:
         type: string
         default: ''
       # Note that this is the _name_ of a secret containing the key, not the key itself.
-      extra-repo-deploy-key: 
+      extra-repo-deploy-key:
         required: false
         type: string
         default: ''
@@ -127,14 +130,35 @@ jobs:
       id: get_epoch_time
       run: echo "RAPIDS_EPOCH_TIMESTAMP=$(date +%s)" >> "${GITHUB_OUTPUT}"
 
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
+    steps:
+      - name: Compute Build Matrix
+        id: compute-matrix
+        run: |
+          set -eo pipefail
+
+          export MATRIX='
+          - { ctk: "11.8.0", arch: "amd64", python: "3.8" }
+          - { ctk: "11.8.0", arch: "amd64", python: "3.9" }
+          - { ctk: "11.8.0", arch: "amd64", python: "3.10" }
+          - { ctk: "11.8.0", arch: "arm64", python: "3.8" }
+          - { ctk: "11.8.0", arch: "arm64", python: "3.9" }
+          - { ctk: "11.8.0", arch: "arm64", python: "3.10" }
+          '
+
+          echo "MATRIX=$(
+            yq -n -o json 'env(MATRIX)' | \
+            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+          )" >> ${GITHUB_OUTPUT}
+
   wheel-build:
     name: cibuildwheel ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}
-    needs: wheel-epoch-timestamp
+    needs: [wheel-epoch-timestamp, compute-matrix]
     strategy:
-      matrix:
-        python: ['3.8', '3.9', '3.10']
-        arch: [amd64, arm64]
-        ctk: ['11.8.0']
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
     container:
       # ctk version of the cibw container is irrelevant in the manylinux case

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -96,6 +96,10 @@ on:
         type: boolean
         default: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   actions: none
   checks: none

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -20,6 +20,9 @@ on:
       package-name:
         required: true
         type: string
+      matrix_filter:
+        type: string
+        default: "."
 
       # test settings
       test-docker-options:
@@ -79,24 +82,25 @@ jobs:
       - name: Compute test matrix
         id: compute-matrix
         run: |
-          export MATRICES=$(cat <<EOF
-          {
-            "pull-request": [
-              { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
-              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "smoke", "test-command": "${{ inputs.test-smoketest }}", "gpu": "a100", "driver": "525" }
-            ],
-            "nightly": [
-              { "arch": "amd64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
-              { "arch": "amd64", "python": "3.9", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
-              { "arch": "amd64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu18.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "v100", "driver": "525" },
-              { "arch": "arm64", "python": "3.8", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" },
-              { "arch": "arm64", "python": "3.10", "ctk": "11.8.0", "image": "ubuntu20.04", "test-type": "unit", "test-command": "${{ inputs.test-unittest }}", "gpu": "a100", "driver": "525" }
-            ]
-          }
-          EOF)
+          export MATRICES='
+            pull-request:
+              - { arch: "amd64", python: "3.8", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
+              - { arch: "arm64", python: "3.8", ctk: "11.8.0", image: "ubuntu20.04", test-type: "smoke", test-command: "${{ inputs.test-smoketest }}", gpu: "a100", driver: "525" }
+            nightly:
+              - { arch: "amd64", python: "3.8", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
+              - { arch: "amd64", python: "3.9", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
+              - { arch: "amd64", python: "3.10", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
+              - { arch: "arm64", python: "3.8", ctk: "11.8.0", image: "ubuntu20.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "a100", driver: "525" }
+              - { arch: "arm64", python: "3.10", ctk: "11.8.0", image: "ubuntu20.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "a100", driver: "525" }
+          '
 
-          export TEST_MATRIX=$(jq -nc 'env.MATRICES | fromjson | .[env.BUILD_TYPE]')
-          echo "MATRIX=$(jq -nc 'env.TEST_MATRIX | fromjson | {include: .}')" >> ${GITHUB_OUTPUT}
+          TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
+          export TEST_MATRIX
+
+          echo "MATRIX=$(
+            yq -n -o json 'env(TEST_MATRIX)' | \
+            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+          )" >> ${GITHUB_OUTPUT}
 
   wheel-test:
     name: wheel ${{ matrix.test-type }} test ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -43,6 +43,10 @@ on:
         type: string
         default: 'true'
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   actions: none
   checks: none
@@ -74,8 +78,6 @@ jobs:
           fi
       - name: Compute test matrix
         id: compute-matrix
-        # use bash to support inherit_errexit so that $(jq) subshell failures can propagate
-        shell: bash
         run: |
           export MATRICES=$(cat <<EOF
           {

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -94,30 +94,30 @@ jobs:
           EOF)
 
           export TEST_MATRIX=$(jq -nc 'env.MATRICES | fromjson | .[env.BUILD_TYPE]')
-          echo "MATRIX=$(jq -nc 'env.TEST_MATRIX | fromjson | {includes: .}')" >> ${GITHUB_OUTPUT}
+          echo "MATRIX=$(jq -nc 'env.TEST_MATRIX | fromjson | {include: .}')" >> ${GITHUB_OUTPUT}
 
   wheel-test:
-    name: wheel ${{ matrix.includes.test-type }} test ${{ matrix.includes.arch }} ${{ matrix.includes.python }} ${{ matrix.includes.ctk }}
+    name: wheel ${{ matrix.test-type }} test ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}
     needs: wheel-test-compute-matrix
     strategy:
       matrix: ${{ fromJSON(needs.wheel-test-compute-matrix.outputs.MATRIX) }}
     runs-on:
       - self-hosted
       - linux
-      - ${{ matrix.includes.arch }}
-      - gpu-${{ matrix.includes.gpu }}-${{ matrix.includes.driver }}-1
+      - ${{ matrix.arch }}
+      - gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
     container:
-      image: "rapidsai/citestwheel:cuda-devel-${{ matrix.includes.ctk }}-${{ matrix.includes.image }}"
+      image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-${{ matrix.image }}"
       options: ${{ inputs.test-docker-options }}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
-        RAPIDS_PY_VERSION: ${{ matrix.includes.python }}
+        RAPIDS_PY_VERSION: ${{ matrix.python }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         RAPIDS_BEFORE_TEST_COMMANDS_AMD64: ${{ inputs.test-before-amd64 }}
         RAPIDS_BEFORE_TEST_COMMANDS_ARM64: ${{ inputs.test-before-arm64 }}
         PIP_EXTRA_INDEX_URL: "https://pypi.k8s.rapids.ai/simple"
         CIBW_TEST_EXTRAS: "test"
-        CIBW_TEST_COMMAND: ${{ matrix.includes.test-command }}
+        CIBW_TEST_COMMAND: ${{ matrix.test-command }}
     steps:
     - uses: aws-actions/configure-aws-credentials@v1-node16
       with:
@@ -149,7 +149,7 @@ jobs:
     - name: Set CTK-related vars from input CTK versions
       uses: rapidsai/shared-action-workflows/wheel-ctk-name-gen@branch-23.06
       with:
-        ctk: ${{ matrix.includes.ctk }}
+        ctk: ${{ matrix.ctk }}
         package-name: ${{ inputs.package-name }}
 
     - name: Run citestwheel

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -39,6 +39,10 @@ on:
         type: boolean
         default: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   actions: none
   checks: none
@@ -123,7 +127,6 @@ jobs:
         fi
 
         python -m pip wheel -w ./dist ${{ inputs.package-dir }} --no-deps -vvv
-      shell: bash
 
     - name: Upload wheels to downloads.rapids.ai
       run: rapids-upload-wheels-to-s3 dist

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -21,6 +21,10 @@ on:
         required: true
         type: string
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   actions: none
   checks: none

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -29,6 +29,10 @@ on:
         type: string
         default: 'true'
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   actions: none
   checks: none


### PR DESCRIPTION
Similar to #62, except for `wheel` workflows instead of `conda` workflows.

This PR also sets the default `shell` to `bash` for consistency with the `conda` workflows.

Closes #63.