### PR TITLE
`wheels-manylinux-test.yml` Fix

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> ${GITHUB_OUTPUT}
+          )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix
     timeout-minutes: 480

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -52,10 +52,10 @@ jobs:
         run: |
           set -eo pipefail
 
-          export MATRIX='
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
-          '
+          export MATRIX="
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10' }
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10' }
+          "
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -93,7 +93,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> ${GITHUB_OUTPUT}
+          )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -60,28 +60,28 @@ jobs:
         run: |
           set -eo pipefail
 
-          export MATRICES='
+          export MATRICES="
             pull-request:
-              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
             nightly:
-              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8", GPU: "a100", DRIVER: "525" }
-              - { CUDA_VER: "11.5.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.5.1", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
             ext_nightly:
-              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "t4", DRIVER: "525" }
-          '
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 't4', DRIVER: '525' }
+          "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
           export TEST_MATRIX

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> ${GITHUB_OUTPUT}
+          )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -52,12 +52,12 @@ jobs:
         run: |
           set -eo pipefail
 
-          export MATRIX='
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.8" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.8" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10" }
-          - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10" }
-          '
+          export MATRIX="
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.8' }
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.8' }
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10' }
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10' }
+          "
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -63,28 +63,28 @@ jobs:
         run: |
           set -eo pipefail
 
-          export MATRICES='
+          export MATRICES="
             pull-request:
-              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
             nightly:
-              - { CUDA_VER: "11.2.2", LINUX_VER: "centos7", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.8", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.4.1", LINUX_VER: "ubuntu20.04", ARCH: "arm64", PY_VER: "3.8", GPU: "a100", DRIVER: "525" }
-              - { CUDA_VER: "11.5.1", LINUX_VER: "ubuntu20.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.5.1", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "450" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "ubuntu22.04", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "amd64", PY_VER: "3.10", GPU: "v100", DRIVER: "525" }
-              - { CUDA_VER: "11.8.0", LINUX_VER: "rockylinux8", ARCH: "arm64", PY_VER: "3.10", GPU: "a100", DRIVER: "525" }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
             ext_nightly:
-              - { CUDA_VER: "11.2.2", LINUX_VER: "ubuntu22.04", ARCH: "amd64", PY_VER: "3.10", GPU: "t4", DRIVER: "525" }
-          '
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 't4', DRIVER: '525' }
+          "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
           export TEST_MATRIX

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> ${GITHUB_OUTPUT}
+          )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -140,14 +140,14 @@ jobs:
         run: |
           set -eo pipefail
 
-          export MATRIX='
-          - { ctk: "11.8.0", arch: "amd64", python: "3.8" }
-          - { ctk: "11.8.0", arch: "amd64", python: "3.9" }
-          - { ctk: "11.8.0", arch: "amd64", python: "3.10" }
-          - { ctk: "11.8.0", arch: "arm64", python: "3.8" }
-          - { ctk: "11.8.0", arch: "arm64", python: "3.9" }
-          - { ctk: "11.8.0", arch: "arm64", python: "3.10" }
-          '
+          export MATRIX="
+          - { ctk: '11.8.0', arch: 'amd64', python: '3.8' }
+          - { ctk: '11.8.0', arch: 'amd64', python: '3.9' }
+          - { ctk: '11.8.0', arch: 'amd64', python: '3.10' }
+          - { ctk: '11.8.0', arch: 'arm64', python: '3.8' }
+          - { ctk: '11.8.0', arch: 'arm64', python: '3.9' }
+          - { ctk: '11.8.0', arch: 'arm64', python: '3.10' }
+          "
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -152,7 +152,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> ${GITHUB_OUTPUT}
+          )" | tee --append "${GITHUB_OUTPUT}"
 
   wheel-build:
     name: cibuildwheel ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -103,7 +103,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> "${GITHUB_OUTPUT}"
+          )" | tee --append "${GITHUB_OUTPUT}"
 
   wheel-test:
     name: wheel ${{ matrix.test-type }} test ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -81,18 +81,21 @@ jobs:
           fi
       - name: Compute test matrix
         id: compute-matrix
+        env:
+          SMOKE_TEST_CMD: ${{ inputs.test-smoketest }}
+          UNIT_TEST_CMD: ${{ inputs.test-unittest }}
         run: |
-          export MATRICES='
+          export MATRICES="
             pull-request:
-              - { arch: "amd64", python: "3.8", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
-              - { arch: "arm64", python: "3.8", ctk: "11.8.0", image: "ubuntu20.04", test-type: "smoke", test-command: "${{ inputs.test-smoketest }}", gpu: "a100", driver: "525" }
+              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
+              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: '525' }
             nightly:
-              - { arch: "amd64", python: "3.8", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
-              - { arch: "amd64", python: "3.9", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
-              - { arch: "amd64", python: "3.10", ctk: "11.8.0", image: "ubuntu18.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "v100", driver: "525" }
-              - { arch: "arm64", python: "3.8", ctk: "11.8.0", image: "ubuntu20.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "a100", driver: "525" }
-              - { arch: "arm64", python: "3.10", ctk: "11.8.0", image: "ubuntu20.04", test-type: "unit", test-command: "${{ inputs.test-unittest }}", gpu: "a100", driver: "525" }
-          '
+              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
+              - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
+              - { arch: 'amd64', python: '3.10', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
+              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: '525' }
+              - { arch: 'arm64', python: '3.10', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: '525' }
+          "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
           export TEST_MATRIX
@@ -100,7 +103,7 @@ jobs:
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
             jq -c '${{ inputs.matrix_filter }} | {include: .}' \
-          )" >> ${GITHUB_OUTPUT}
+          )" >> "${GITHUB_OUTPUT}"
 
   wheel-test:
     name: wheel ${{ matrix.test-type }} test ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -85,6 +85,8 @@ jobs:
           SMOKE_TEST_CMD: ${{ inputs.test-smoketest }}
           UNIT_TEST_CMD: ${{ inputs.test-unittest }}
         run: |
+          set -eo pipefail
+
           export MATRICES="
             pull-request:
               - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }


### PR DESCRIPTION
#63 included a bug that caused the wheel unit and smoke test commands to not be properly escaped.

The fix was to inject those values as `bash` variables rather than with a GitHub Action's expression.

This required updating the outer quotations for the `MATRICES` environment variable in `.github/workflows/wheels-manylinux-test.yml` to use `"` instead of `'`.

For consistency, I've updated the other matrix environment variables to match this style.

Additionally, I've switched the final matrix output to use `tee --append` instead of `>>` so that the matrix value is printed to the GitHub Actions console. This is useful for inspecting the final computed matrices.