### PR TITLE
Merge `py-39` into `branch-23.06`

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -62,25 +62,25 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             nightly:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: '525' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             ext_nightly:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 't4', DRIVER: '525' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 't4', DRIVER: 'latest' }
           "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
@@ -99,11 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
-    runs-on:
-      - self-hosted
-      - linux
-      - gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1
-      - ${{ matrix.ARCH }}
+    runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     env:
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -62,17 +62,17 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             nightly:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
               - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -53,8 +53,8 @@ jobs:
           set -eo pipefail
 
           export MATRIX="
-          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.8' }
-          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.8' }
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.9' }
+          - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.9' }
           - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10' }
           - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10' }
           "

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -65,25 +65,25 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             nightly:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: '525' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '450' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: '525' }
-              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: '525' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             ext_nightly:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 't4', DRIVER: '525' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 't4', DRIVER: 'latest' }
           "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
@@ -102,11 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
-    runs-on:
-      - self-hosted
-      - linux
-      - gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1
-      - ${{ matrix.ARCH }}
+    runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     env:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -65,17 +65,17 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             nightly:
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.8', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.8', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
               - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -48,7 +48,7 @@ jobs:
   build:
     strategy:
       fail-fast: false
-    runs-on: ${{ fromJSON(contains(inputs.node_type, 'cpu') && format('"linux-{0}-{1}"', inputs.arch, inputs.node_type) || format('{{"labels":["self-hosted", "linux", "{0}", "{1}"]}}', inputs.arch, inputs.node_type)) }}
+    runs-on: "linux-${{ inputs.arch }}-${{ inputs.node_type }}"
     container:
       image: ${{ inputs.container_image }}
       env:

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -131,10 +131,8 @@ jobs:
           set -eo pipefail
 
           export MATRIX="
-          - { ctk: '11.8.0', arch: 'amd64', python: '3.8' }
           - { ctk: '11.8.0', arch: 'amd64', python: '3.9' }
           - { ctk: '11.8.0', arch: 'amd64', python: '3.10' }
-          - { ctk: '11.8.0', arch: 'arm64', python: '3.8' }
           - { ctk: '11.8.0', arch: 'arm64', python: '3.9' }
           - { ctk: '11.8.0', arch: 'arm64', python: '3.10' }
           "

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -89,14 +89,14 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
-              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: '525' }
+              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
             nightly:
-              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
-              - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
-              - { arch: 'amd64', python: '3.10', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: '525' }
-              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: '525' }
-              - { arch: 'arm64', python: '3.10', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: '525' }
+              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.10', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.10', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
           "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
@@ -112,11 +112,7 @@ jobs:
     needs: wheel-test-compute-matrix
     strategy:
       matrix: ${{ fromJSON(needs.wheel-test-compute-matrix.outputs.MATRIX) }}
-    runs-on:
-      - self-hosted
-      - linux
-      - ${{ matrix.arch }}
-      - gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
+    runs-on: "linux-${{ matrix.arch }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1"
     container:
       image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-${{ matrix.image }}"
       options: ${{ inputs.test-docker-options }}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -89,13 +89,12 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
-              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.9', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
             nightly:
-              - { arch: 'amd64', python: '3.8', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'amd64', python: '3.10', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
-              - { arch: 'arm64', python: '3.8', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.9', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
               - { arch: 'arm64', python: '3.10', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
           "
 

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -71,7 +71,7 @@ jobs:
       image: "rapidsai/cibuildwheel:cuda-runtime-${{ matrix.ctk }}-ubuntu20.04"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_PY_VERSION: "3.8"
+        RAPIDS_PY_VERSION: "3.9"
 
     steps:
     - uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -59,7 +59,7 @@ jobs:
       image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-ubuntu18.04"
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
-        RAPIDS_PY_VERSION: "3.8"
+        RAPIDS_PY_VERSION: "3.9"
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         RAPIDS_BEFORE_TEST_COMMANDS_AMD64: ${{ inputs.test-before }}
         CIBW_TEST_EXTRAS: "test"

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -51,7 +51,7 @@ permissions:
 jobs:
   wheel-test:
     name: wheel test pure
-    runs-on: [self-hosted, linux, amd64, gpu-v100-525-1]
+    runs-on: linux-amd64-gpu-v100-latest-1
     strategy:
       matrix:
         ctk: ["11.8.0"]

--- a/cibuildwheel/action.yml
+++ b/cibuildwheel/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'Path to output wheels'
     required: true
   python-version:
-    description: 'python version e.g. 3.8'
+    description: 'python version e.g. 3.9'
     required: true
   cuda-suffix:
     description: 'Add a -cu11-style suffix to wheel name'


### PR DESCRIPTION
All of our repositories are successfully building against `py-39`, so it's safe to now merge this into `branch-23.06`.

After this PR is merged, we can reconfigure the downstream repositories to use `branch-23.06` instead of `py-39`.

**Only after all of the downstream repository PRs are merged should we delete the `py-39` branch.**