### PR TITLE
CUDA 12.0 pip support

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -203,6 +203,9 @@ jobs:
         pyenv global ${{ matrix.python }}
 
         # Run before-wheel command
+        CU_VER=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+        echo $CU_VER
+        echo ${{ inputs.before-wheel }}
         ${{ inputs.before-wheel }}
 
         cd "${{ inputs.package-dir }}"

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -233,7 +233,7 @@ jobs:
         printf 'machine pypi.k8s.rapids.ai\n\tlogin cibuildwheel\n\tpassword ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}\n' > ~/.netrc
 
         # Hardcode the output dir
-        python -m pip wheel . -w dist -vvv --no-deps
+        python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
         # Repair the wheel
         cd dist

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -227,6 +227,7 @@ jobs:
 
         # Set up for pip installation of dependencies from the nightly index
         export PIP_EXTRA_INDEX_URL=https://pypi.k8s.rapids.ai/simple
+        export PIP_FIND_LINKS=/local-wheelhouse
 
         # Store internal pypi credentials before any step that may download wheels
         printf 'machine pypi.k8s.rapids.ai\n\tlogin cibuildwheel\n\tpassword ${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}\n' > ~/.netrc

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -119,6 +119,10 @@ jobs:
           - { ctk: '11.8.0', arch: 'amd64', python: '3.10', image: 'rapidsai/manylinux_v2_2014:cuda-devel-11.8.0-centos7' }
           - { ctk: '11.8.0', arch: 'arm64', python: '3.9', image: 'rapidsai/manylinux_v2_2_31:cuda-devel-11.8.0-ubuntu20.04' }
           - { ctk: '11.8.0', arch: 'arm64', python: '3.10', image: 'rapidsai/manylinux_v2_2_31:cuda-devel-11.8.0-ubuntu20.04' }
+          - { ctk: '12.0.1', arch: 'amd64', python: '3.9', image: 'rapidsai/manylinux_v2_2014:cuda-devel-12.0.1-centos7'}
+          - { ctk: '12.0.1', arch: 'amd64', python: '3.10', image: 'rapidsai/manylinux_v2_2014:cuda-devel-12.0.1-centos7' }
+          - { ctk: '12.0.1', arch: 'arm64', python: '3.9', image: 'rapidsai/manylinux_v2_2_31:cuda-devel-12.0.1-ubuntu20.04' }
+          - { ctk: '12.0.1', arch: 'arm64', python: '3.10', image: 'rapidsai/manylinux_v2_2_31:cuda-devel-12.0.1-ubuntu20.04' }
           "
 
           echo "MATRIX=$(

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -90,12 +90,18 @@ jobs:
           export MATRICES="
             pull-request:
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.9', ctk: '12.0.1', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'arm64', python: '3.9', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.9', ctk: '12.0.1', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
             nightly:
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'amd64', python: '3.10', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'arm64', python: '3.9', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
               - { arch: 'arm64', python: '3.10', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.9', ctk: '12.0.1', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.10', ctk: '12.0.1', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.9', ctk: '12.0.1', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
+              - { arch: 'arm64', python: '3.10', ctk: '12.0.1', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'a100', driver: 'latest' }
           "
 
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -109,7 +109,7 @@ jobs:
         # CUDA versions
         PIP_CU_VERSION=$(echo ${RAPIDS_PY_WHEEL_CUDA_SUFFIX} | sed "s/-//")
 
-        "${{ inputs.before-wheel }}"
+        ${{ inputs.before-wheel }}
 
     - name: Build pure python wheel with pip wheel
       run: |

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -107,7 +107,7 @@ jobs:
         # This variable needs to be used as an un-evaluated string by downstream libraries
         # to support pulling wheels built from a previous workflow for different
         # CUDA versions
-        PIP_CU_VERSION=$(echo ${{ RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+        PIP_CU_VERSION=$(echo ${RAPIDS_PY_WHEEL_CUDA_SUFFIX} | sed "s/-//")
 
         "${{ inputs.before-wheel }}"
 

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -65,7 +65,7 @@ jobs:
     needs: wheel-epoch-timestamp
     strategy:
       matrix:
-        ctk: ["11.8.0"]
+        ctk: ["11.8.0", "12.0.1"]
     runs-on: ubuntu-latest
     container:
       # Always use the manylinux container built on x86 to match the runner arch

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: linux-amd64-gpu-v100-latest-1
     strategy:
       matrix:
-        ctk: ["11.8.0"]
+        ctk: ["11.8.0", "12.0.1"]
     container:
       image: "rapidsai/citestwheel:cuda-devel-${{ matrix.ctk }}-ubuntu18.04"
       env:

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -103,7 +103,7 @@ jobs:
         # This variable needs to be used as an un-evaluated string by downstream libraries
         # to support pulling wheels built from a previous workflow for different
         # CUDA versions
-        PIP_CU_VERSION=$(echo ${{ RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+        PIP_CU_VERSION=$(echo ${RAPIDS_PY_WHEEL_CUDA_SUFFIX} | sed "s/-//")
         
         export RAPIDS_BEFORE_TEST_COMMANDS_AMD64="${{ inputs.test-before }}"
 


### PR DESCRIPTION
This PR enables CUDA 12.0 CI workflows for pip wheels. It is currently a subset of the changes in the `cuda-120` branch, which also adds conda.

Closes #76 