### PR TITLE
Support allowing wheels built for different CUDA versions in latter stages

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -203,6 +203,9 @@ jobs:
         pyenv global ${{ matrix.python }}
 
         # Run before-wheel command
+        CU_VER=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+        echo $CU_VER
+        echo ${{ inputs.before-wheel }}
         ${{ inputs.before-wheel }}
 
         cd "${{ inputs.package-dir }}"

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -205,8 +205,6 @@ jobs:
 
         # Run before-wheel command
         CU_VER=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
-        echo $CU_VER
-        echo ${{ inputs.before-wheel }}
         ${{ inputs.before-wheel }}
 
         cd "${{ inputs.package-dir }}"

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -200,11 +200,13 @@ jobs:
 
     - name: Build and repair the wheel
       run: |
-        set -x
         pyenv global ${{ matrix.python }}
 
         # Run before-wheel command
-        CU_VER=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+        # This variable needs to be used as an un-evaluated string by downstream libraries
+        # to support pulling wheels built from a previous workflow for different
+        # CUDA versions
+        PIP_CU_VERSION=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
         ${{ inputs.before-wheel }}
 
         cd "${{ inputs.package-dir }}"

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -200,6 +200,7 @@ jobs:
 
     - name: Build and repair the wheel
       run: |
+        set -x
         pyenv global ${{ matrix.python }}
 
         # Run before-wheel command

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -164,12 +164,12 @@ jobs:
 
     - name: Run citestwheel
       run: |
-      # This variable needs to be used as an un-evaluated string by downstream libraries
-      # to support pulling wheels built from a previous workflow for different
-      # CUDA versions
-      PIP_CU_VERSION=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+        # This variable needs to be used as an un-evaluated string by downstream libraries
+        # to support pulling wheels built from a previous workflow for different
+        # CUDA versions
+        PIP_CU_VERSION=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
 
-      export RAPIDS_BEFORE_TEST_COMMANDS_AMD64="${{ inputs.test-before-amd64 }}"
-      export RAPIDS_BEFORE_TEST_COMMANDS_ARM64="${{ inputs.test-before-arm64 }}"
+        export RAPIDS_BEFORE_TEST_COMMANDS_AMD64="${{ inputs.test-before-amd64 }}"
+        export RAPIDS_BEFORE_TEST_COMMANDS_ARM64="${{ inputs.test-before-arm64 }}"
 
-      /citestwheel.sh
+        /citestwheel.sh

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -125,8 +125,6 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
         RAPIDS_PY_VERSION: ${{ matrix.python }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_BEFORE_TEST_COMMANDS_AMD64: ${{ inputs.test-before-amd64 }}
-        RAPIDS_BEFORE_TEST_COMMANDS_ARM64: ${{ inputs.test-before-arm64 }}
         PIP_EXTRA_INDEX_URL: "https://pypi.k8s.rapids.ai/simple"
         CIBW_TEST_EXTRAS: "test"
         CIBW_TEST_COMMAND: ${{ matrix.test-command }}
@@ -165,4 +163,13 @@ jobs:
         package-name: ${{ inputs.package-name }}
 
     - name: Run citestwheel
-      run: /citestwheel.sh
+      run: |
+      # This variable needs to be used as an un-evaluated string by downstream libraries
+      # to support pulling wheels built from a previous workflow for different
+      # CUDA versions
+      PIP_CU_VERSION=$(echo ${{ env.RAPIDS_PY_WHEEL_CUDA_SUFFIX }} | sed "s/-//")
+
+      export RAPIDS_BEFORE_TEST_COMMANDS_AMD64="${{ inputs.test-before-amd64 }}"
+      export RAPIDS_BEFORE_TEST_COMMANDS_ARM64="${{ inputs.test-before-arm64 }}"
+
+      /citestwheel.sh


### PR DESCRIPTION
This PR allows downstream repos to pass an un-evaluated string in a job that requires a wheel built from a previous job.

For example, currently commands are hard-coded as:
```
"RAPIDS_PY_WHEEL_NAME=pylibraft_cu11 ..."
```

Downstream repos will now be able to specify this command as:
```
"RAPIDS_PY_WHEEL_NAME=pylibraft_${{ '${PIP_CU_VERSION}' }} ..."
```

An upstream workflow now just needs to ensure `${PIP_CU_VERSION}` is set as `cu11/cu12/...` to download a wheel built from a previous job such that CUDA versions are correctly matched.