### PR TITLE
Add `GH_TOKEN` to conda build jobs

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -94,6 +94,8 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: C++ build
         run: ${{ inputs.build_script }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -95,6 +95,8 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python build
         run: ${{ inputs.build_script }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}


### PR DESCRIPTION
This PR adds a `GH_TOKEN` to the conda build jobs to account for the changes in the PR below:

- https://github.com/rapidsai/gha-tools/pull/53