### PR TITLE
Set `actions` permissions to `read`

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -27,7 +27,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -27,7 +27,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -27,7 +27,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -30,7 +30,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -24,7 +24,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -30,7 +30,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -78,7 +78,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/wheels-manylinux-publish.yml
+++ b/.github/workflows/wheels-manylinux-publish.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -51,7 +51,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -34,7 +34,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/wheels-pure-publish.yml
+++ b/.github/workflows/wheels-pure-publish.yml
@@ -26,7 +26,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -34,7 +34,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: none
+  actions: read
   checks: none
   contents: read
   deployments: none


### PR DESCRIPTION
Because of the changes in https://github.com/rapidsai/gha-tools/pull/53, we need to enable `actions: read` access for the `GITHUB_TOKEN` provided by GitHub Actions so that it can read workflow data for private repositories.