### PR TITLE
Reduce `arm64` PR matrix for wheels

### DIFF
--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -91,7 +91,6 @@ jobs:
             pull-request:
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'amd64', python: '3.9', ctk: '12.0.1', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
-              - { arch: 'arm64', python: '3.9', ctk: '11.8.0', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
               - { arch: 'arm64', python: '3.9', ctk: '12.0.1', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
             nightly:
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }


### PR DESCRIPTION
This PR reduces the matrix size for testing on `arm` nodes for PRs.

We have very limited (8) `arm` GPU runners.

Currently, a single PR will take up 4 GPUs (half of our `arm` capacity):

- 1 `arm` GPU for conda C++ tests
- 1 `arm` GPU for conda Python tests
- 2 `arm` GPUs for wheel tests

This will cause really long queues for the `arm` GPU runners.

It will be fine to reduce the pull-request matrix size for `arm` and rely on nightly tests for additional confidence.