### PR TITLE
Add `RAPIDS_DOCS_DIR` to `custom-job.yaml`

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -49,6 +49,8 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: "linux-${{ inputs.arch }}-${{ inputs.node_type }}"
+    env:
+      RAPIDS_DOCS_DIR: /tmp/docs
     container:
       image: ${{ inputs.container_image }}
       env:


### PR DESCRIPTION
This PR is necessary for https://github.com/rapidsai/gha-tools/pull/56.

Note: the path in this PR uses `/tmp` instead of the `${{ github.workspace }}` convention used in places like this: https://github.com/rapidsai/shared-action-workflows/blob/914f969d872d37d57f5449407635fc3ddb8d8e4b/.github/workflows/conda-cpp-tests.yaml#L103-L105

The problem with `github.workspace` is that it's the same directory that the code is checked out to. Therefore since a `docs` directory already exists in `cudf`'s root directory, this would cause problems. Assuming this `/tmp` path works as expected, I will open up a follow-up PR to update the `github.workspace` instances to follow this convention.