### PR TITLE
Remove `sccache` config from wheel building workflow

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -211,18 +211,12 @@ jobs:
 
         cd "${{ inputs.package-dir }}"
 
-        # sccache configuration
-        export SCCACHE_S3_KEY_PREFIX=gha-cibw
-        export SCCACHE_REGION=us-east-2
-        export SCCACHE_IDLE_TIMEOUT=32768
-        export SCCACHE_BUCKET=rapids-sccache-east
-        export SCCACHE_S3_USE_SSL=true
         export AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
         export AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
         export AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
 
         # Set up skbuild options. Enable sccache in skbuild config options
-        export SKBUILD_CONFIGURE_OPTIONS="${{ inputs.skbuild-configure-options}} -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=/usr/bin/sccache"
+        export SKBUILD_CONFIGURE_OPTIONS="${{ inputs.skbuild-configure-options}}"
         export SKBUILD_BUILD_OPTIONS="${{ inputs.skbuild-build-options }}"
 
         # Set up for pip installation of dependencies from the nightly index


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cibuildwheel-imgs/pull/21

Closes https://github.com/rapidsai/shared-action-workflows/issues/82