### PR TITLE
Removes `auditwheel` `--plat` arg in favor of using `AUDITWHEEL_PLAT` env var in image

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -237,11 +237,8 @@ jobs:
 
         # Repair the wheel
         cd dist
-        if [[ "${{ matrix.arch }}" == "amd64" ]]; then
-          python -m auditwheel repair -w . ${{ inputs.package-name }}* --plat manylinux_2_17_x86_64
-        else
-          python -m auditwheel repair -w . ${{ inputs.package-name }}* --plat manylinux_2_31_aarch64
-        fi
+
+	python -m auditwheel repair -w . ${{ inputs.package-name }}*
 
         if [[ "${{ matrix.arch }}" == "arm64" ]]; then
           ${{ inputs.post-repair-arm64 }}

--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -237,8 +237,7 @@ jobs:
 
         # Repair the wheel
         cd dist
-
-	python -m auditwheel repair -w . ${{ inputs.package-name }}*
+        python -m auditwheel repair -w . ${{ inputs.package-name }}*
 
         if [[ "${{ matrix.arch }}" == "arm64" ]]; then
           ${{ inputs.post-repair-arm64 }}


### PR DESCRIPTION
closes #80 
Merge after rapidsai/cibuildwheel-imgs#20