### PR TITLE
Move check-generated-files into other-checks.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Check workflow file dependencies
         if: ${{ inputs.enable_check_pr_job_dependencies }}
         run: rapids-check-pr-job-dependencies
+      - name: Run rapids-dependency-file-checker
+        if: ${{ inputs.enable_check_generated_files }}
+        run: rapids-dependency-file-checker ${{ inputs.dependency_generator_config_file_path }}
   check-style:
     if: ${{ inputs.enable_check_style }}
     runs-on: ubuntu-latest
@@ -69,13 +72,3 @@ jobs:
         run: ci/check_style.sh
         env:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
-  check-generated-files:
-    if: ${{ inputs.enable_check_generated_files }}
-    runs-on: ubuntu-latest
-    container:
-      image: rapidsai/ci:latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Run rapids-dependency-file-checker
-        run: rapids-dependency-file-checker ${{ inputs.dependency_generator_config_file_path }}


### PR DESCRIPTION
This makes the `check-generated-files` check a part of the `other-checks` job. For most (all?) RAPIDS repos, this check has been disabled and replaced by a `pre-commit` hook.

![image](https://github.com/rapidsai/shared-action-workflows/assets/3943761/41e43a71-060c-4412-a059-5c99ccf4575a)
