### PR TITLE
Test Python 3.10 wheels / Ubuntu 20.04 in PR builds.

### DIFF
--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -90,7 +90,7 @@ jobs:
           export MATRICES="
             pull-request:
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
-              - { arch: 'amd64', python: '3.9', ctk: '12.0.1', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
+              - { arch: 'amd64', python: '3.10', ctk: '12.0.1', image: 'ubuntu20.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }
               - { arch: 'arm64', python: '3.9', ctk: '12.0.1', image: 'ubuntu20.04', test-type: 'smoke', test-command: ${SMOKE_TEST_CMD}, gpu: 'a100', driver: 'latest' }
             nightly:
               - { arch: 'amd64', python: '3.9', ctk: '11.8.0', image: 'ubuntu18.04', test-type: 'unit', test-command: ${UNIT_TEST_CMD}, gpu: 'v100', driver: 'latest' }

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -104,5 +104,5 @@ jobs:
 
         # citestwheel.sh implicitly uses this to download previously built wheels
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
-        
+
         /citestwheel.sh


### PR DESCRIPTION
This PR updates our CI matrix so that our "full" wheel tests cover a slightly wider range of platforms.

We test CUDA 11 and CUDA 12 on each PR, but we only cover Python 3.9 and Ubuntu 18.04. I propose that we test two more-orthogonal configurations with the full test suite (non-smoke tests):
```diff
  CUDA 11, Python 3.9, Ubuntu 18.04, amd64
- CUDA 12, Python 3.9, Ubuntu 18.04, amd64
+ CUDA 12, Python 3.10, Ubuntu 20.04, amd64
```