### PR TITLE
Export `RAPIDS_CUDA_VER` in wheel build workflow

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -189,6 +189,7 @@ jobs:
         versioneer_override="$(rapids-pip-wheel-version ${{ needs.wheel-epoch-timestamp.outputs.rapids_epoch_timestamp }})"
 
         PIP_CU_VERSION="$(rapids-wheel-ctk-name-gen ${{ matrix.ctk }})"
+        export RAPIDS_CUDA_VERSION="${{ matrix.ctk }}"
 
         bash ci/release/apply_wheel_modifications.sh ${versioneer_override} "-${PIP_CU_VERSION}"
         echo "The package name and/or version was modified in the package source. The git diff is:"


### PR DESCRIPTION
In https://github.com/rapidsai/ucx-py/pull/955, we need to generate a cuda-suffix to patch wheels for `ucx-py`, explained [here](https://github.com/rapidsai/ucx-py/pull/954#issuecomment-1572316176)