### PR TITLE
Remove `RAPIDS_DOCS_DIR` from `custom-job.yaml`

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -49,8 +49,6 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: "linux-${{ inputs.arch }}-${{ inputs.node_type }}"
-    env:
-      RAPIDS_DOCS_DIR: /tmp/docs
     container:
       image: ${{ inputs.container_image }}
       env:


### PR DESCRIPTION
In hindsight, this variable isn't needed at the workflow level since the only workflow step that uses it is the last one.

Therefore we can just set the variable's value in the script that's run in the last workflow step.