### PR TITLE
Bump CUDA versions

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -63,18 +63,18 @@ jobs:
           export MATRICES="
             pull-request:
               - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             nightly:
               - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.5.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.5.2', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -66,18 +66,18 @@ jobs:
           export MATRICES="
             pull-request:
               - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
             nightly:
               - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.1', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.5.1', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.5.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
+              - { CUDA_VER: '11.5.2', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }


### PR DESCRIPTION
This PR updates the CUDA versions to the latest supported patch versions.

Depends on:
  - https://github.com/rapidsai/mambaforge-cuda/pull/35
  - https://github.com/rapidsai/ci-imgs/pull/54

See:
  - https://gitlab.com/nvidia/container-images/cuda/-/issues/209#note_1452067531
  - https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/container_tags.pdf