### PR TITLE
Add support for uploading arbitrary artifacts to wheel workflows

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -133,6 +133,8 @@ jobs:
   wheel-build:
     name: cibuildwheel ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}
     needs: [wheel-epoch-timestamp, compute-matrix]
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
@@ -240,3 +242,6 @@ jobs:
         rapids-upload-wheels-to-s3 final_dist
       # Use a shell that loads the rc file so that we get the compiler settings
       shell: bash -leo pipefail {0}
+    - name: Upload additional artifacts
+        if: "!cancelled()"
+        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -114,6 +114,8 @@ jobs:
   wheel-test:
     name: wheel ${{ matrix.test-type }} test ${{ matrix.arch }} ${{ matrix.python }} ${{ matrix.ctk }}
     needs: wheel-test-compute-matrix
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     strategy:
       matrix: ${{ fromJSON(needs.wheel-test-compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.arch }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1"
@@ -170,3 +172,6 @@ jobs:
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
 
         /citestwheel.sh
+      - name: Upload additional artifacts
+        if: "!cancelled()"
+        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -172,6 +172,6 @@ jobs:
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
 
         /citestwheel.sh
-      - name: Upload additional artifacts
-        if: "!cancelled()"
-        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+    - name: Upload additional artifacts
+      if: "!cancelled()"
+      run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -120,6 +120,6 @@ jobs:
         # on this variable being set
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
         rapids-upload-wheels-to-s3 dist
-      - name: Upload additional artifacts
-        if: "!cancelled()"
-        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+    - name: Upload additional artifacts
+      if: "!cancelled()"
+      run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -63,6 +63,8 @@ jobs:
   wheel-build:
     name: wheel build pure ${{ matrix.ctk }}
     needs: wheel-epoch-timestamp
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     strategy:
       matrix:
         ctk: ["11.8.0", "12.0.1"]
@@ -118,3 +120,6 @@ jobs:
         # on this variable being set
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
         rapids-upload-wheels-to-s3 dist
+      - name: Upload additional artifacts
+        if: "!cancelled()"
+        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -130,6 +130,6 @@ jobs:
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
 
         /citestwheel.sh
-      - name: Upload additional artifacts
-        if: "!cancelled()"
-        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+    - name: Upload additional artifacts
+      if: "!cancelled()"
+      run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -74,6 +74,8 @@ jobs:
   wheel-test:
     name: wheel test pure
     needs: compute-matrix
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     runs-on: linux-amd64-gpu-v100-latest-1
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
@@ -128,3 +130,6 @@ jobs:
         export RAPIDS_PY_WHEEL_NAME="${{ inputs.package-name }}_${PIP_CU_VERSION}"
 
         /citestwheel.sh
+      - name: Upload additional artifacts
+        if: "!cancelled()"
+        run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}


### PR DESCRIPTION
Similarly to #51, this PR adds support for uploading arbitrary artifacts for wheel workflows.