### PR TITLE
Remove extraneous environment variable declarations

### DIFF
--- a/.github/workflows/wheels-manylinux-build.yml
+++ b/.github/workflows/wheels-manylinux-build.yml
@@ -117,10 +117,10 @@ jobs:
           export MATRIX="
           - { ctk: '11.8.0', arch: 'amd64', python: '3.9', linux_ver: 'centos7' }
           - { ctk: '11.8.0', arch: 'amd64', python: '3.10', linux_ver: 'centos7' }
-          - { ctk: '11.8.0', arch: 'arm64', python: '3.9',  linux_ver: 'ubuntu20.04' }
+          - { ctk: '11.8.0', arch: 'arm64', python: '3.9', linux_ver: 'ubuntu20.04' }
           - { ctk: '11.8.0', arch: 'arm64', python: '3.10', linux_ver: 'ubuntu20.04' }
-          - { ctk: '12.0.1', arch: 'amd64', python: '3.9',  linux_ver: 'centos7' }
-          - { ctk: '12.0.1', arch: 'amd64', python: '3.10',  linux_ver: 'centos7' }
+          - { ctk: '12.0.1', arch: 'amd64', python: '3.9', linux_ver: 'centos7' }
+          - { ctk: '12.0.1', arch: 'amd64', python: '3.10', linux_ver: 'centos7' }
           - { ctk: '12.0.1', arch: 'arm64', python: '3.9', linux_ver: 'ubuntu20.04' }
           - { ctk: '12.0.1', arch: 'arm64', python: '3.10', linux_ver: 'ubuntu20.04' }
           "
@@ -142,7 +142,6 @@ jobs:
       image: "rapidsai/ci-wheel:cuda${{ matrix.ctk }}-${{ matrix.linux_ver }}-py${{ matrix.python }}"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_PY_VERSION: ${{ matrix.python }}
 
     steps:
     - uses: aws-actions/configure-aws-credentials@v2
@@ -190,7 +189,6 @@ jobs:
         versioneer_override="$(rapids-pip-wheel-version ${{ needs.wheel-epoch-timestamp.outputs.rapids_epoch_timestamp }})"
 
         PIP_CU_VERSION="$(rapids-wheel-ctk-name-gen ${{ matrix.ctk }})"
-        export RAPIDS_CUDA_VERSION="${{ matrix.ctk }}"
 
         bash ci/release/apply_wheel_modifications.sh ${versioneer_override} "-${PIP_CU_VERSION}"
         echo "The package name and/or version was modified in the package source. The git diff is:"

--- a/.github/workflows/wheels-manylinux-test.yml
+++ b/.github/workflows/wheels-manylinux-test.yml
@@ -124,7 +124,6 @@ jobs:
       options: ${{ inputs.test-docker-options }}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
-        RAPIDS_PY_VERSION: ${{ matrix.python }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         PIP_EXTRA_INDEX_URL: "https://pypi.k8s.rapids.ai/simple"
         CIBW_TEST_EXTRAS: "test"

--- a/.github/workflows/wheels-pure-build.yml
+++ b/.github/workflows/wheels-pure-build.yml
@@ -74,7 +74,6 @@ jobs:
       image: "rapidsai/ci-wheel:cuda${{ matrix.ctk }}-centos7-py3.10"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_PY_VERSION: "3.10"
 
     steps:
     - uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/wheels-pure-test.yml
+++ b/.github/workflows/wheels-pure-test.yml
@@ -83,7 +83,6 @@ jobs:
       image: "rapidsai/citestwheel:cuda${{ matrix.CUDA_VER }}-ubuntu18.04-py3.10"
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
-        RAPIDS_PY_VERSION: "3.10"
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         CIBW_TEST_EXTRAS: "test"
         CIBW_TEST_COMMAND: ${{ inputs.test-unittest }}


### PR DESCRIPTION
The environment variables removed in this PR are included in our CI images for wheels and can therefore be removed from these workflows.

Depends on https://github.com/rapidsai/cibuildwheel-imgs/pull/30.