### PR TITLE
Add `RAPIDS_ARTIFACT_DIR` to `wheels-build.yaml`

### DIFF
--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -98,9 +98,10 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
       image: "rapidsai/ci-wheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
-
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
 


### PR DESCRIPTION
I inadvertently broke workflows by forgetting to add `RAPIDS_ARTIFACT_DIR` in https://github.com/rapidsai/shared-action-workflows/pull/97