### PR TITLE
add `build-in-devcontainer.yaml` workflow

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -1,0 +1,68 @@
+on:
+  workflow_call:
+    inputs:
+      sha:
+        type: string
+      repo:
+        type: string
+      node_type:
+        type: string
+        default: "cpu4"
+      build_command:
+        type: string
+        required: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "arm64"]
+        cuda: ["11.8", "12.0"]
+        pkgr: ["conda", "pip"]
+        exclude:
+          - { cuda: '12.0', arch: 'arm64', pkgr: 'conda' }
+    runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
+    permissions:
+      id-token: write # This is required for configure-aws-credentials
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+      - name: Check if repo has devcontainer
+        run: |
+          if test -f .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
+            echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
+          else
+            echo "HAS_DEVCONTAINER=false" >> "${GITHUB_ENV}";
+          fi
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+        name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+        name: Copy devcontainer.json file up one level
+        run: |
+          cp \
+            .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
+            .devcontainer/devcontainer.json
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+        name: Run build in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          runCmd: "${{ inputs.build_command }}"
+          env: |
+            SCCACHE_REGION=${{ vars.AWS_REGION }}
+            AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
+            AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
+            AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -12,6 +12,21 @@ on:
         type: string
         required: true
 
+permissions:
+  actions: read
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
     strategy:
@@ -21,9 +36,6 @@ jobs:
         cuda: ["12.0"]
         pkgr: ["conda", "pip"]
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
-    permissions:
-      contents: read
-      id-token: write # This is required for configure-aws-credentials
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -85,71 +85,58 @@ jobs:
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
-
             if test -n "${{ inputs.extra-repo-deploy-key }}"; then
 
-              echo "starting ssh-agent:";
               eval "$(ssh-agent -s)";
-              echo "adding private key:"
               ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
 
               re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
 
               ssh-add -L | while read -r line; do
-                echo "public key:";
-                echo "$line";
+                pub="$(cut -d' ' -f2 <<< "${line}")";
+                url="$(cut -d' ' -f3 <<< "${line}")";
 
-                pub="$(cut -d' ' -f2 <<< "$line")";
-                url="$(cut -d' ' -f3 <<< "$line")";
-
-                if ! test -f ~/.ssh/key-$pub; then
-                  cat <<______EOF | tee -a ~/.ssh/key-$pub;
-            $line
+                if ! test -f ~/.ssh/key-${pub}; then
+                  cat <<______EOF | tee -a ~/.ssh/key-${pub} >/dev/null
+            ${line}
             ______EOF
                 fi
 
-                if [[ $url =~ $re ]]; then
+                if [[ ${url} =~ ${re} ]]; then
                   host="${BASH_REMATCH[3]}";
                   repo="${BASH_REMATCH[4]//.git/}";
 
-                  cat <<______EOF | tee -a ~/.gitconfig
-            [url "git@key-$pub.$host:$repo"]
-              insteadOf = https://$host/$repo
-              insteadOf = git@$host:$repo
-              insteadOf = ssh://git@$host/$repo
+                  cat <<______EOF | tee -a ~/.gitconfig >/dev/null
+            [url "git@key-${pub}.${host}:${repo}"]
+              insteadOf = https://${host}/${repo}
+              insteadOf = git@${host}:${repo}
+              insteadOf = ssh://git@${host}/${repo}
             ______EOF
 
-                  cat <<______EOF | tee -a ~/.ssh/config
-            Host key-$pub.$host
-                HostName $host
-                IdentityFile /home/coder/.ssh/key-$pub
+                  cat <<______EOF | tee -a ~/.ssh/config >/dev/null
+            Host key-${pub}.${host}
+                HostName ${host}
+                IdentityFile /home/coder/.ssh/key-${pub}
                 IdentitiesOnly yes
             ______EOF
+
+                  unset host;
+                  unset repo;
                 fi
+
+                unset pub;
+                unset url;
               done
+
+              unset line;
 
               curl -s "https://api.github.com/meta" | \
                 jq -r '.ssh_keys | map("github.com \(.)") | .[]' | \
-                tee ~/.ssh/known_hosts;
-            fi
+                tee ~/.ssh/known_hosts >/dev/null
 
-            chmod 0700 ~/.ssh;
-            chmod 0600 ~/.ssh/*;
-
-            ls -all ~/.ssh/;
-            if test -f ~/.ssh/config; then
-              echo "ssh/config:"
-              cat ~/.ssh/config;
-            fi
-            if test -f ~/.ssh/known_hosts; then
-              echo "ssh/known_hosts:"
-              cat ~/.ssh/known_hosts;
-            fi
-            if test -f ~/.gitconfig; then
-              echo "gitconfig:"
-              cat ~/.gitconfig;
+              chmod 0700 ~/.ssh;
+              chmod 0600 ~/.ssh/*;
             fi
 
             cd ~/"${REPOSITORY}";
-
             ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -11,6 +11,10 @@ on:
       build_command:
         type: string
         required: true
+      ssh-deploy-keys:
+        type: string
+        default: ''
+        required: false
 
 permissions:
   actions: read
@@ -62,28 +66,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' && inputs.ssh-deploy-keys != '' }}
         name: Set up ssh-agent
         uses: webfactory/ssh-agent@v0.8.0
         with:
-          ssh-private-key: |
-            ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
-            ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
+          ssh-private-key: ${{ inputs.ssh-deploy-keys }}
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
-          cp \
-            .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
-            .devcontainer/devcontainer.json
-          if test -f "$HOME"/.gitconfig; then
-            cp "$HOME"/.gitconfig .devcontainer;
-          fi
-          if test -d "$HOME"/.ssh; then
-            cp -ar "$HOME"/.ssh .devcontainer;
-            if test -f .devcontainer/.ssh/config; then
-              sed -i "s@$HOME@/home/coder@g" .devcontainer/.ssh/config;
-            fi
+          cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json .devcontainer/devcontainer.json;
+          if test -n "${SSH_AGENT_PID:-}" != ''; then
+            cp -ar "$HOME"/.gitconfig "$HOME"/.ssh .devcontainer;
+            sed -i "s@$HOME@/home/coder@g" .devcontainer/.ssh/config;
+            curl -s "https://api.github.com/meta" \
+            | jq -r '.ssh_keys | map("github.com \(.)") | .[]' \
+            | tee .devcontainer/.ssh/known_hosts >/dev/null;
           fi
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
@@ -98,25 +96,18 @@ jobs:
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
             cd ~/"${REPOSITORY}";
+            if test -d .devcontainer/.ssh; then
+              cp -ar .devcontainer/.ssh/* ~/.ssh/;
+            fi
             if test -f .devcontainer/.gitconfig; then
               cat .devcontainer/.gitconfig | tee -a ~/.gitconfig;
-              rm .devcontainer/.gitconfig;
             fi
-            if test -d .devcontainer/.ssh; then
-              if test -f .devcontainer/.ssh/config; then
-                cat .devcontainer/.ssh/config | tee -a ~/.ssh/config;
-                rm .devcontainer/.ssh/config;
-              fi
-              if test -f .devcontainer/.ssh/known_hosts; then
-                cat .devcontainer/.ssh/known_hosts | tee -a ~/.ssh/known_hosts;
-                rm .devcontainer/.ssh/known_hosts;
-              fi
-              cp .devcontainer/.ssh/* ~/.ssh/;
-              rm -rf .devcontainer/.ssh
-            fi
-            chmod 700 ~/.ssh;
-            chmod 600 ~/.ssh/*;
+            rm -rf .devcontainer/.ssh .devcontainer/.gitconfig;
+
+            chmod 0700 ~/.ssh;
+            chmod 0600 ~/.ssh/*;
             sudo chown -R coder:coder ~/.ssh;
+
             echo "gitconfig:"
             cat ~/.gitconfig;
             echo "ssh/config:"
@@ -124,4 +115,12 @@ jobs:
             echo "ssh/known_hosts:"
             cat ~/.ssh/known_hosts;
             ls -all ~/.ssh/;
+
+            echo "SSH_AGENT_PID: '${SSH_AGENT_PID:-}'"
+            echo "SSH_AUTH_SOCK: '${SSH_AUTH_SOCK:-}'"
+            if test -z "${SSH_AUTH_SOCK:-}"; then
+              eval "$(ssh-agent -s)";
+              ssh-add -L;
+            fi
+
             ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -83,6 +83,8 @@ jobs:
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
+            set -e;
+
             cat <<EOF > ~/.config/pip/pip.conf
             [global]
             extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple
@@ -91,56 +93,9 @@ jobs:
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;
 
             if ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key }}"; then
-
-              eval "$(ssh-agent -s)";
+              if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;
               ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
-
-              re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
-
-              ssh-add -L | while read -r line; do
-                pub="$(cut -d' ' -f2 <<< "${line}")";
-                url="$(cut -d' ' -f3 <<< "${line}")";
-
-                if ! test -f ~/.ssh/key-${pub}; then
-                  cat <<______EOF | tee -a ~/.ssh/key-${pub} >/dev/null
-            ${line}
-            ______EOF
-                fi
-
-                if [[ ${url} =~ ${re} ]]; then
-                  host="${BASH_REMATCH[3]}";
-                  repo="${BASH_REMATCH[4]//.git/}";
-
-                  cat <<______EOF | tee -a ~/.gitconfig >/dev/null
-            [url "git@key-${pub}.${host}:${repo}"]
-              insteadOf = https://${host}/${repo}
-              insteadOf = git@${host}:${repo}
-              insteadOf = ssh://git@${host}/${repo}
-            ______EOF
-
-                  cat <<______EOF | tee -a ~/.ssh/config >/dev/null
-            Host key-${pub}.${host}
-                HostName ${host}
-                IdentityFile /home/coder/.ssh/key-${pub}
-                IdentitiesOnly yes
-            ______EOF
-
-                  unset host;
-                  unset repo;
-                fi
-
-                unset pub;
-                unset url;
-              done
-
-              unset line;
-
-              curl -s "https://api.github.com/meta" | \
-                jq -r '.ssh_keys | map("github.com \(.)") | .[]' | \
-                tee ~/.ssh/known_hosts >/dev/null
-
-              chmod 0700 ~/.ssh;
-              chmod 0600 ~/.ssh/*;
+              devcontainer-utils-init-ssh-deploy-keys || true;
             fi
 
             cd ~/"${REPOSITORY}";

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -95,7 +95,7 @@ jobs:
           runCmd: |
             set -e;
 
-            cat <<EOF > ~/.config/pip/pip.conf
+            cat <<EOF | tee -a ~/.config/pip/pip.conf >/dev/null
             [global]
             extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple
             EOF

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -70,12 +70,11 @@ jobs:
             ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
             ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Copy devcontainer.json file up one level and adjust ssh config
+        name: Copy devcontainer.json file up one level
         run: |
           cp \
             .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
             .devcontainer/devcontainer.json
-          sed -i "s@$HOME@/home/coder@g" "$HOME/.ssh/config";
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -12,6 +12,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
           cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json .devcontainer/devcontainer.json;
-          if test -n "${SSH_AGENT_PID:-}" != ''; then
+          if test -n "${SSH_AGENT_PID:-}"; then
             cp -ar "$HOME"/.gitconfig "$HOME"/.ssh .devcontainer;
             sed -i "s@$HOME@/home/coder@g" .devcontainer/.ssh/config;
             curl -s "https://api.github.com/meta" \

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -109,18 +109,25 @@ jobs:
             chmod 0600 ~/.ssh/*;
             sudo chown -R coder:coder ~/.ssh;
 
-            echo "gitconfig:"
-            cat ~/.gitconfig;
-            echo "ssh/config:"
-            cat ~/.ssh/config;
-            echo "ssh/known_hosts:"
-            cat ~/.ssh/known_hosts;
             ls -all ~/.ssh/;
+            if test -f ~/.ssh/config; then
+              echo "ssh/config:"
+              cat ~/.ssh/config;
+            fi
+            if test -f ~/.ssh/known_hosts; then
+              echo "ssh/known_hosts:"
+              cat ~/.ssh/known_hosts;
+            fi
+            if test -f ~/.gitconfig; then
+              echo "gitconfig:"
+              cat ~/.gitconfig;
+            fi
 
-            echo "SSH_AGENT_PID: '${SSH_AGENT_PID:-}'"
-            echo "SSH_AUTH_SOCK: '${SSH_AUTH_SOCK:-}'"
+            echo "SSH_AGENT_PID: '${SSH_AGENT_PID:-}'";
+            echo "SSH_AUTH_SOCK: '${SSH_AUTH_SOCK:-}'";
             if test -z "${SSH_AUTH_SOCK:-}"; then
               eval "$(ssh-agent -s)";
+              ssh-add ~/.ssh/key-*;
               ssh-add -L;
             fi
 

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -61,11 +61,19 @@ jobs:
         with:
           node-version: '16'
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Copy devcontainer.json file up one level
+        name: Set up ssh-agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: |
+            ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
+            ${{ secrets.CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY }}
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+        name: Copy devcontainer.json file up one level and adjust ssh config
         run: |
           cp \
             .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
             .devcontainer/devcontainer.json
+          sed -i "s@$HOME@/home/coder@g" "$HOME/.ssh/config";
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -75,7 +75,7 @@ jobs:
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
-          mkdir -p data;
+          mkdir -p data/empty-folder;
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
           cp repo/.devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
              repo/.devcontainer/devcontainer.json;

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -82,6 +82,7 @@ jobs:
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+            EXTRA_REPO_DEPLOY_KEY=${{ secrets[inputs.extra-repo-deploy-key] }}
           runCmd: |
             cat <<EOF > ~/.config/pip/pip.conf
             [global]
@@ -90,10 +91,10 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;
 
-            if test -n "${{ inputs.extra-repo-deploy-key }}"; then
+            if ! grep -qE "^$" <<< "${EXTRA_REPO_DEPLOY_KEY:-}"; then
 
               eval "$(ssh-agent -s)";
-              ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
+              ssh-add - <<< "${EXTRA_REPO_DEPLOY_KEY:-}";
 
               re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
 

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -95,7 +95,7 @@ jobs:
           runCmd: |
             set -e;
 
-            stat ~/.config/pip;
+            mkdir -p ~/.config/pip/;
             cat <<EOF >> ~/.config/pip/pip.conf
             [global]
             extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -71,11 +71,11 @@ jobs:
         uses: actions/cache@v3
         with:
           key: "cuda${{ matrix.cuda }}-${{ matrix.pkgr }}-${{ matrix.arch }}-devcontainer-data"
-          path: data
+          path: "${{ github.workspace }}/data"
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
-          mkdir -p data/empty-folder;
+          mkdir -p "${{ github.workspace }}/data/empty-folder";
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
           cp repo/.devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
              repo/.devcontainer/devcontainer.json;
@@ -85,7 +85,7 @@ jobs:
         with:
           push: never
           subFolder: repo
-          userDataFolder: data
+          userDataFolder: "${{ github.workspace }}/data"
           env: |
             REPOSITORY=${{ env.REPOSITORY }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -114,6 +114,9 @@ jobs:
               cp .devcontainer/.ssh/* ~/.ssh/;
               rm -rf .devcontainer/.ssh
             fi
+            chmod 700 ~/.ssh;
+            chmod 600 ~/.ssh/*;
+            sudo chown -R coder:coder ~/.ssh;
             echo "gitconfig:"
             cat ~/.gitconfig;
             echo "ssh/config:"

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -47,10 +47,9 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-          path: repo
       - name: Check if repo has devcontainer
         run: |
-          if test -f repo/.devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
+          if test -f .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
             echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
           else
             echo "HAS_DEVCONTAINER=false" >> "${GITHUB_ENV}";
@@ -67,25 +66,16 @@ jobs:
         with:
           node-version: '16'
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Cache devcontainer build files
-        uses: actions/cache@v3
-        with:
-          key: "cuda${{ matrix.cuda }}-${{ matrix.pkgr }}-${{ matrix.arch }}-devcontainer-data"
-          path: "${{ github.workspace }}/data"
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
-          mkdir -p "${{ github.workspace }}/data/empty-folder";
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
-          cp repo/.devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
-             repo/.devcontainer/devcontainer.json;
+          cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
+             .devcontainer/devcontainer.json;
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3
         with:
           push: never
-          subFolder: repo
-          userDataFolder: "${{ github.workspace }}/data"
           env: |
             REPOSITORY=${{ env.REPOSITORY }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -76,21 +76,14 @@ jobs:
           cp \
             .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
             .devcontainer/devcontainer.json
-          if test -f "$HOME/.gitconfig"; then
-            echo "$HOME/.gitconfig:";
-            cat "$HOME/.gitconfig";
-            cp "$HOME/.gitconfig" .devcontainer/gitconfig;
+          if test -f "$HOME"/.gitconfig; then
+            cp "$HOME"/.gitconfig .devcontainer;
           fi
-          if test -f "$HOME/.ssh/config"; then
-            echo "$HOME/.ssh/config:";
-            cat "$HOME/.ssh/config";
-            cp "$HOME/.ssh/config" .devcontainer/ssh_config;
-            sed -i "s@$HOME@/home/coder@g" ".devcontainer/ssh_config";
-          fi
-          if test -f "$HOME/.ssh/known_hosts"; then
-            echo "$HOME/.ssh/known_hosts:";
-            cat "$HOME/.ssh/known_hosts";
-            cp "$HOME/.ssh/known_hosts" .devcontainer/ssh_known_hosts;
+          if test -d "$HOME"/.ssh; then
+            cp -ar "$HOME"/.ssh .devcontainer;
+            if test -f .devcontainer/.ssh/config; then
+              sed -i "s@$HOME@/home/coder@g" .devcontainer/.ssh/config;
+            fi
           fi
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
@@ -104,17 +97,28 @@ jobs:
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
-            echo "cwd: $(pwd)";
             cd ~/"${REPOSITORY}";
-            echo "REPOSITORY: ${REPOSITORY}";
-            echo "cwd: $(pwd)";
-            cp .devcontainer/gitconfig ~/.gitconfig;
-            cp .devcontainer/ssh_config ~/.ssh/config;
-            cp .devcontainer/ssh_known_hosts ~/.ssh/known_hosts;
+            if test -f .devcontainer/.gitconfig; then
+              cat .devcontainer/.gitconfig | tee -a ~/.gitconfig;
+              rm .devcontainer/.gitconfig;
+            fi
+            if test -d .devcontainer/.ssh; then
+              if test -f .devcontainer/.ssh/config; then
+                cat .devcontainer/.ssh/config | tee -a ~/.ssh/config;
+                rm .devcontainer/.ssh/config;
+              fi
+              if test -f .devcontainer/.ssh/known_hosts; then
+                cat .devcontainer/.ssh/known_hosts | tee -a ~/.ssh/known_hosts;
+                rm .devcontainer/.ssh/known_hosts;
+              fi
+              cp .devcontainer/.ssh/* ~/.ssh/;
+              rm -rf .devcontainer/.ssh
+            fi
             echo "gitconfig:"
             cat ~/.gitconfig;
             echo "ssh/config:"
             cat ~/.ssh/config;
             echo "ssh/known_hosts:"
             cat ~/.ssh/known_hosts;
+            ls -all ~/.ssh/;
             ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -72,6 +72,7 @@ jobs:
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
+          echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
           cp \
             .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
             .devcontainer/devcontainer.json
@@ -97,11 +98,16 @@ jobs:
         with:
           push: never
           env: |
+            REPOSITORY=${{ env.REPOSITORY }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
+            echo "cwd: $(pwd)";
+            cd ~/"${REPOSITORY}";
+            echo "REPOSITORY: ${REPOSITORY}";
+            echo "cwd: $(pwd)";
             cp .devcontainer/gitconfig ~/.gitconfig;
             cp .devcontainer/ssh_config ~/.ssh/config;
             cp .devcontainer/ssh_known_hosts ~/.ssh/known_hosts;

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -83,6 +83,13 @@ jobs:
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
+            cat <<EOF > ~/.config/pip/pip.conf
+            [global]
+            extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple
+            EOF
+
+            rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;
+
             if test -n "${{ inputs.extra-repo-deploy-key }}"; then
 
               eval "$(ssh-agent -s)";

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -95,7 +95,8 @@ jobs:
           runCmd: |
             set -e;
 
-            cat <<EOF | tee -a ~/.config/pip/pip.conf >/dev/null
+            stat ~/.config/pip;
+            cat <<EOF >> ~/.config/pip/pip.conf
             [global]
             extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple
             EOF

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -7,7 +7,7 @@ on:
         type: string
       node_type:
         type: string
-        default: "cpu4"
+        default: "cpu8"
       build_command:
         type: string
         required: true

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -11,10 +11,11 @@ on:
       build_command:
         type: string
         required: true
-      ssh-deploy-keys:
+      # Note that this is the _name_ of a secret containing the key, not the key itself.
+      extra-repo-deploy-key:
+        required: false
         type: string
         default: ''
-        required: false
 
 permissions:
   actions: read
@@ -66,11 +67,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' && inputs.ssh-deploy-keys != '' }}
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' && inputs.extra-repo-deploy-key != '' }}
         name: Set up ssh-agent
         uses: webfactory/ssh-agent@v0.8.0
         with:
-          ssh-private-key: ${{ inputs.ssh-deploy-keys }}
+          ssh-private-key: "${{ secrets[inputs.extra-repo-deploy-key] }}"
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -67,23 +67,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' && inputs.extra-repo-deploy-key != '' }}
-        name: Set up ssh-agent
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: "${{ secrets[inputs.extra-repo-deploy-key] }}"
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
-          cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json .devcontainer/devcontainer.json;
-          if test -n "${SSH_AGENT_PID:-}"; then
-            cp -ar "$HOME"/.gitconfig "$HOME"/.ssh .devcontainer;
-            sed -i "s@$HOME@/home/coder@g" .devcontainer/.ssh/config;
-            curl -s "https://api.github.com/meta" \
-            | jq -r '.ssh_keys | map("github.com \(.)") | .[]' \
-            | tee .devcontainer/.ssh/known_hosts >/dev/null;
-          fi
+          cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
+             .devcontainer/devcontainer.json;
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3
@@ -96,18 +85,56 @@ jobs:
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
-            cd ~/"${REPOSITORY}";
-            if test -d .devcontainer/.ssh; then
-              cp -ar .devcontainer/.ssh/* ~/.ssh/;
+
+            if test -n "${{ inputs.extra-repo-deploy-key }}"; then
+
+              echo "starting ssh-agent:";
+              eval "$(ssh-agent -s)";
+              echo "adding private key:"
+              ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
+
+              re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
+
+              ssh-add -L | while read -r line; do
+                echo "public key:";
+                echo "$line";
+
+                pub="$(cut -d' ' -f2 <<< "$line")";
+                url="$(cut -d' ' -f3 <<< "$line")";
+
+                if ! test -f ~/.ssh/key-$pub; then
+                  cat <<______EOF | tee -a ~/.ssh/key-$pub;
+            $line
+            ______EOF
+                fi
+
+                if [[ $url =~ $re ]]; then
+                  host="${BASH_REMATCH[3]}";
+                  repo="${BASH_REMATCH[4]//.git/}";
+
+                  cat <<______EOF | tee -a ~/.gitconfig
+            [url "git@key-$pub.$host:$repo"]
+              insteadOf = https://$host/$repo
+              insteadOf = git@$host:$repo
+              insteadOf = ssh://git@$host/$repo
+            ______EOF
+
+                  cat <<______EOF | tee -a ~/.ssh/config
+            Host key-$pub.$host
+                HostName $host
+                IdentityFile /home/coder/.ssh/key-$pub
+                IdentitiesOnly yes
+            ______EOF
+                fi
+              done
+
+              curl -s "https://api.github.com/meta" | \
+                jq -r '.ssh_keys | map("github.com \(.)") | .[]' | \
+                tee ~/.ssh/known_hosts;
             fi
-            if test -f .devcontainer/.gitconfig; then
-              cat .devcontainer/.gitconfig | tee -a ~/.gitconfig;
-            fi
-            rm -rf .devcontainer/.ssh .devcontainer/.gitconfig;
 
             chmod 0700 ~/.ssh;
             chmod 0600 ~/.ssh/*;
-            sudo chown -R coder:coder ~/.ssh;
 
             ls -all ~/.ssh/;
             if test -f ~/.ssh/config; then
@@ -123,12 +150,6 @@ jobs:
               cat ~/.gitconfig;
             fi
 
-            echo "SSH_AGENT_PID: '${SSH_AGENT_PID:-}'";
-            echo "SSH_AUTH_SOCK: '${SSH_AUTH_SOCK:-}'";
-            if test -z "${SSH_AUTH_SOCK:-}"; then
-              eval "$(ssh-agent -s)";
-              ssh-add ~/.ssh/key-*;
-              ssh-add -L;
-            fi
+            cd ~/"${REPOSITORY}";
 
             ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -51,8 +51,6 @@ jobs:
         run: |
           if test -f .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
             echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
-            sudo apt update;
-            sudo apt install -y --no-install-recommends openssh-client;
           else
             echo "HAS_DEVCONTAINER=false" >> "${GITHUB_ENV}";
           fi

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -46,6 +46,8 @@ jobs:
         run: |
           if test -f .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
             echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
+            sudo apt update;
+            sudo apt install -y --no-install-recommends openssh-client;
           else
             echo "HAS_DEVCONTAINER=false" >> "${GITHUB_ENV}";
           fi

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -12,9 +12,6 @@ on:
         type: string
         required: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     strategy:
@@ -25,6 +22,7 @@ jobs:
         pkgr: ["conda", "pip"]
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
     permissions:
+      contents: read
       id-token: write # This is required for configure-aws-credentials
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -47,9 +47,10 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+          path: repo
       - name: Check if repo has devcontainer
         run: |
-          if test -f .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
+          if test -f repo/.devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
             echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
           else
             echo "HAS_DEVCONTAINER=false" >> "${GITHUB_ENV}";
@@ -66,16 +67,25 @@ jobs:
         with:
           node-version: '16'
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
+        name: Cache devcontainer build files
+        uses: actions/cache@v3
+        with:
+          key: "cuda${{ matrix.cuda }}-${{ matrix.pkgr }}-${{ matrix.arch }}-devcontainer-data"
+          path: data
+      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Copy devcontainer.json file up one level
         run: |
+          mkdir -p data;
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
-          cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
-             .devcontainer/devcontainer.json;
+          cp repo/.devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
+             repo/.devcontainer/devcontainer.json;
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3
         with:
           push: never
+          subFolder: repo
+          userDataFolder: data
           env: |
             REPOSITORY=${{ env.REPOSITORY }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -64,7 +64,7 @@ jobs:
           node-version: '16'
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Set up ssh-agent
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: |
             ${{ secrets.CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY }}
@@ -75,14 +75,40 @@ jobs:
           cp \
             .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
             .devcontainer/devcontainer.json
+          if test -f "$HOME/.gitconfig"; then
+            echo "$HOME/.gitconfig:";
+            cat "$HOME/.gitconfig";
+            cp "$HOME/.gitconfig" .devcontainer/gitconfig;
+          fi
+          if test -f "$HOME/.ssh/config"; then
+            echo "$HOME/.ssh/config:";
+            cat "$HOME/.ssh/config";
+            cp "$HOME/.ssh/config" .devcontainer/ssh_config;
+            sed -i "s@$HOME@/home/coder@g" ".devcontainer/ssh_config";
+          fi
+          if test -f "$HOME/.ssh/known_hosts"; then
+            echo "$HOME/.ssh/known_hosts:";
+            cat "$HOME/.ssh/known_hosts";
+            cp "$HOME/.ssh/known_hosts" .devcontainer/ssh_known_hosts;
+          fi
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3
         with:
           push: never
-          runCmd: "${{ inputs.build_command }}"
           env: |
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+          runCmd: |
+            cp .devcontainer/gitconfig ~/.gitconfig;
+            cp .devcontainer/ssh_config ~/.ssh/config;
+            cp .devcontainer/ssh_known_hosts ~/.ssh/known_hosts;
+            echo "gitconfig:"
+            cat ~/.gitconfig;
+            echo "ssh/config:"
+            cat ~/.ssh/config;
+            echo "ssh/known_hosts:"
+            cat ~/.ssh/known_hosts;
+            ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -17,11 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm64"]
-        cuda: ["11.8", "12.0"]
+        arch: ["amd64"]
+        cuda: ["12.0"]
         pkgr: ["conda", "pip"]
-        exclude:
-          - { cuda: '12.0', arch: 'arm64', pkgr: 'conda' }
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
     permissions:
       id-token: write # This is required for configure-aws-credentials

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -82,7 +82,6 @@ jobs:
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
-            EXTRA_REPO_DEPLOY_KEY=${{ secrets[inputs.extra-repo-deploy-key] }}
           runCmd: |
             cat <<EOF > ~/.config/pip/pip.conf
             [global]
@@ -91,10 +90,10 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;
 
-            if ! grep -qE "^$" <<< "${EXTRA_REPO_DEPLOY_KEY:-}"; then
+            if ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key }}"; then
 
               eval "$(ssh-agent -s)";
-              ssh-add - <<< "${EXTRA_REPO_DEPLOY_KEY:-}";
+              ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
 
               re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
 


### PR DESCRIPTION
Adds a `build-in-devcontainer.yaml` reusable workflow that can be used to build the code for a RAPIDS project in each of its devcontainers.

For example, here's how it would be used in RMM's [`pr.yaml`](https://github.com/rapidsai/rmm/pull/1328/files#diff-1eb4e5fd5611777d4e597ef299a1cb5ba8050c28a2dabbd4fbc56205d69e5ddaR79-R85), and [here's](https://github.com/rapidsai/rmm/actions/runs/5945307022/job/16124167473) the resulting devcontainer build matrix jobs:
```yaml
  devcontainer:
    secrets: inherit
    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.10
    with:
      build_command: |
        build-rmm-cpp -DBUILD_BENCHMARKS=ON
        build-rmm-python
```

Building the code in devcontainers in CI means the build cache is populated for developers, who are populating the build cache for CI, which is populating the build cache for developers... in an endless loop of build caching goodness.