### PR TITLE
Only match `.yaml` files in `update-version.sh`

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -22,6 +22,6 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-for FILE in .github/workflows/*.{yaml,yml}; do
+for FILE in .github/workflows/*.yaml; do
   sed_runner "/rapidsai\/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done


### PR DESCRIPTION
Since there are no `.yml` files in `.github/workflows`, the final `FILE` will be the literal `.github/workflows/*.yml` which is passed to `sed_runner` and fails.

Other repos do not try to match both extensions, but if we want to do that here, it would be more complex code using `find` and a read-while loop.