### PR TITLE
Remove 11.4 tests

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -66,7 +66,6 @@ jobs:
           export MATRICES="
             pull-request:
               - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
@@ -74,9 +73,6 @@ jobs:
               - { CUDA_VER: '11.2.2', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.2.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-              - { CUDA_VER: '11.4.3', LINUX_VER: 'ubuntu20.04', ARCH: 'arm64', PY_VER: '3.9', GPU: 'a100', DRIVER: 'latest' }
               - { CUDA_VER: '11.5.2', LINUX_VER: 'ubuntu20.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.5.2', LINUX_VER: 'rockylinux8', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }


### PR DESCRIPTION
This removal was discussed on Slack, but would probably like approval from at least both @ajschmidt8 and @raydouglass before proceeding in case there is some other reason we need this job.