### PR TITLE
Use self-hosted runners for uploading packages

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     container:
       image: rapidsai/ci-conda:latest
       env:

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   wheel-publish:
     name: wheels publish
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     container:
       # ctk version of the container is irrelevant in the publish step
       # it's simply a launcher for twine


### PR DESCRIPTION
GitHub-hosted runners have limited space which can cause issues with some jobs:

- https://github.com/rapidsai/cugraph/actions/runs/6428765880/attempts/1

This PR updates our shared workflows that are responsible for uploading wheel and conda packages to use self-hosted runners, which have significantly more space available.