### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     container:
       image: rapidsai/ci-conda:latest
       env:

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   wheel-publish:
     name: wheels publish
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     container:
       # ctk version of the container is irrelevant in the publish step
       # it's simply a launcher for twine


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.