### PR TITLE
Add ability run script to set a job_output that is re-exported

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    outputs:
+      job_output:
+        description: "job_output set by inputs.run_script"
+        value: "${{ jobs.build.outputs.job_output }}"
     inputs:
       build_type:
         required: true
@@ -25,6 +29,7 @@ on:
         required: true
         type: string
 
+
 defaults:
   run:
     shell: bash
@@ -46,6 +51,11 @@ permissions:
 
 jobs:
   build:
+    outputs:
+      # Export run_step_output to dependent jobs
+      # To set this, the script must do
+      # echo "job_output=WHATEVER" >> "${GITHUB_OUTPUT}"
+      job_output: ${{ steps.run-step.outputs.job_output }}
     strategy:
       fail-fast: false
     runs-on: "linux-${{ inputs.arch }}-${{ inputs.node_type }}"
@@ -81,4 +91,5 @@ jobs:
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
       - name: Run script
+        id: run-step
         run: ${{ inputs.run_script }}


### PR DESCRIPTION
If the run script sets job_output in the GITHUB_OUTPUTS environment variable this will now be exported as job_output to downstream dependants of this job.